### PR TITLE
P1P2Monitor: Added platformio configuration for the P1P2Monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+examples/**/.pio
+examples/**/.vscode/

--- a/examples/P1P2MQTT-bridge/P1P2MQTT-bridge.cpp
+++ b/examples/P1P2MQTT-bridge/P1P2MQTT-bridge.cpp
@@ -52,7 +52,7 @@
  * Additionally, it can reset and program the ATmega328P if corresponding connections are available
  */
 
-#include "ESPTelnet.h"
+#include <ESPTelnet.h>
 #include "P1P2_Config.h"
 #include "P1P2_NetworkParams.h"
 #include "P1P2_HomeAssistant.h"
@@ -669,6 +669,17 @@ int16_t mqttBufferReadChar (void) {
   mqttBufferFree++;
   return c;
 }
+
+// forwad declarations
+void saveRebootReason(const byte x);
+byte rebootReason(void);
+void saveRTC(void);
+void process_for_mqtt(byte* rb, int n);
+void printWelcome(void);
+void reportState(void);
+void configTZ (void);
+void buildMqttTopic();
+
 
 uint16_t snprintfLength = 0;
 uint16_t snprintfLengthMax = 0;

--- a/examples/P1P2MQTT-bridge/P1P2_Config.h
+++ b/examples/P1P2MQTT-bridge/P1P2_Config.h
@@ -110,11 +110,16 @@
 #define SAVEPACKETS
 // to save memory to avoid ESP instability (until P1P2MQTT is released): do not #define SAVESCHEDULE // format of schedules will change to JSON format in P1P2MQTT
 
-#define WELCOMESTRING "P1P2MQTT bridge v0.9.54rc1"
-#define HA_SW "0.9.54rc1"
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
 #define SW_PATCH_VERSION 54
 #define SW_MINOR_VERSION 9
 #define SW_MAJOR_VERSION 0
+
+#define VERSIONSTRING TOSTRING(SW_MAJOR_VERSION) "." TOSTRING(SW_MINOR_VERSION) "." TOSTRING(SW_PATCH_VERSION) "rc1"
+#define WELCOMESTRING "P1P2MQTT bridge v" VERSIONSTRING
+#define HA_SW VERSIONSTRING
 
 #define ARDUINO_OTA
 #define WEBSERVER // adds webserver to update firmware of ESP

--- a/examples/P1P2MQTT-bridge/extra_script.py
+++ b/examples/P1P2MQTT-bridge/extra_script.py
@@ -1,0 +1,2 @@
+Import("env")
+env.Replace(PROGNAME="P1P2MQTT_v%s-%s" % (env.GetProjectOption("custom_version"), env["PIOENV"]))

--- a/examples/P1P2MQTT-bridge/platformio.ini
+++ b/examples/P1P2MQTT-bridge/platformio.ini
@@ -1,0 +1,54 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir=.
+
+[env]
+platform = espressif8266
+board = esp12e
+framework = arduino
+platform_packages = framework-arduinoespressif8266 @ file://../../OSS-dependencies/Arduino_BSP/esp8266-3.0.2-modified.zip
+lib_ignore =  me-no-dev/ESPAsyncTCP
+lib_deps = 
+    file://../../OSS-dependencies/libraries/ESPAsyncTCP-master-modified.zip
+    bblanchon/ArduinoJson@~6.11.3
+    tzapu/WiFiManager@~2.0.17
+    marvinroger/AsyncMqttClient@~0.9.0
+    https://github.com/LennartHennigs/ESPTelnet.git#2.0.0
+    ; lennarthennigs/ESP Telnet@~2.1.1
+
+build_flags =  -w -D P1P2MQTT_BRIDGE -D VERSION=${this.custom_version}
+extra_scripts = pre:extra_script.py
+custom_version = 0.9.54
+
+[env:Daikin-E]
+build_flags = -D E_SERIES ${env.build_flags}
+
+[env:Daikin-F]
+build_flags = -D F_SERIES ${env.build_flags}
+
+[env:Hitachi]
+build_flags = -D H_SERIES ${env.build_flags}
+
+[env:Mitsubishi]
+build_flags = -D M_SERIES ${env.build_flags}
+
+[env:MHI]
+build_flags = -D S_SERIES ${env.build_flags}
+
+[env:Toshiba]
+build_flags = -D T_SERIES ${env.build_flags}
+
+[env:Sanyo]
+build_flags = -D S_SERIES ${env.build_flags}
+
+[env:Panasonic]
+build_flags = -D P_SERIES ${env.build_flags}

--- a/examples/P1P2Monitor/P1P2Config.h
+++ b/examples/P1P2Monitor/P1P2Config.h
@@ -74,10 +74,15 @@
 #define SERIAL_MAGICSTRING "1P2P" // Serial input line should start with SERIAL_MAGICSTRING, otherwise input line is ignored
 #endif /* F_CPU */
 
-#define WELCOMESTRING "P1P2Monitor v0.9.54"
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
 #define SW_PATCH_VERSION 54
 #define SW_MINOR_VERSION 9
 #define SW_MAJOR_VERSION 0
+
+#define VERSIONSTRING TOSTRING(SW_MAJOR_VERSION) "." TOSTRING(SW_MINOR_VERSION) "." TOSTRING(SW_PATCH_VERSION) "rc1"
+#define WELCOMESTRING "P1P2Monitor v" VERSIONSTRING
 
 #ifdef MHI_SERIES
 #define INIT_MHI_FORMAT 1 // 1 (default) for conversion from/to 3-bit-per-byte format with check-sum, 0 for raw data

--- a/examples/P1P2Monitor/P1P2Monitor.cpp
+++ b/examples/P1P2Monitor/P1P2Monitor.cpp
@@ -455,7 +455,7 @@ void setup() {
 
 // scanint and scanhex are used to save dynamic memory usage in main loop
 int scanint(char* s, uint16_t &b) {
-  return sscanf(s,"%d",&b);
+  return sscanf(s,"%hu",&b);
 }
 
 int scanhex(char* s, uint16_t &b) {

--- a/examples/P1P2Monitor/extra_script.py
+++ b/examples/P1P2Monitor/extra_script.py
@@ -1,0 +1,2 @@
+Import("env")
+env.Replace(PROGNAME="P1P2Monitor_v%s-%s" % (env.GetProjectOption("custom_version"), env["PIOENV"]))

--- a/examples/P1P2Monitor/platformio.ini
+++ b/examples/P1P2Monitor/platformio.ini
@@ -1,0 +1,49 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir=.
+
+[env]
+platform = atmelavr
+platform_packages = framework-arduino-avr-minicore@2.1.3
+framework = arduino
+board = ATmega328P
+; board = uno
+
+lib_deps = symlink://../../
+
+build_flags = -Wall  -D VERSION=${this.custom_version}
+extra_scripts = pre:extra_script.py
+custom_version = 0.9.54
+
+[env:Daikin-E]
+build_flags = -D E_SERIES ${env.build_flags}
+
+[env:Daikin-F]
+build_flags = -D F_SERIES ${env.build_flags}
+
+[env:Hitachi]
+build_flags = -D H_SERIES ${env.build_flags}
+
+[env:Mitsubishi]
+build_flags = -D M_SERIES ${env.build_flags}
+
+[env:MHI]
+build_flags = -D S_SERIES ${env.build_flags}
+
+[env:Toshiba]
+build_flags = -D T_SERIES ${env.build_flags}
+
+[env:Sanyo]
+build_flags = -D S_SERIES ${env.build_flags}
+
+[env:Panasonic]
+build_flags = -D P_SERIES ${env.build_flags}


### PR DESCRIPTION
Hi @Arnold-n 

I have created platformio configuration for the Monitor. This allows you to use VSCode for development which is much mode comfortable.

You can display error and warnings:
![image](https://github.com/user-attachments/assets/cb8fdb2c-609f-46c1-9be8-ef83ba10b913)

You can define build profiles. Which means that you can setup Arduino BSP and libraries as you wish in very easy way. Such definitions allows you to define different versions of libraries for each version as the configuration is stored together with sources.
![image](https://github.com/user-attachments/assets/cdfe0799-8776-496f-8cdd-129c6204083f)

And probably also debug code (I have not tried it yet)  - https://www.youtube.com/watch?v=T7OGXvEXY9Y

Another possible advantage is to use Copilot for code refactoring, improvements and writing of unit tests. 

I have created configurations for both the Monitor and the Bridge.

**Bridge build:**

CONFIGURATION: https://docs.platformio.org/page/boards/espressif8266/esp12e.html
PLATFORM: Espressif 8266 (4.2.1) > Espressif ESP8266 ESP-12E
HARDWARE: ESP8266 80MHz, 80KB RAM, 4MB Flash
PACKAGES: 
 - framework-arduinoespressif8266 @ 3.0.2 
 - tool-esptool @ 1.413.0 (4.13) 
 - tool-esptoolpy @ 1.30000.201119 (3.0.0) 
 - toolchain-xtensa @ 2.100300.220621 (10.3.0)
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 41 compatible libraries
Scanning dependencies...
Dependency Graph
|-- ESP AsyncTCP @ 2.0.1
|-- ArduinoJson @ 6.11.5
|-- WiFiManager @ 2.0.17
|-- AsyncMqttClient @ 0.9.0
|-- ESP Telnet @ 2.0.0+sha.90f9546
|-- lwIP_w5500 @ 1
|-- ArduinoOTA @ 1.0
|-- DNSServer @ 1.1.1
|-- EEPROM @ 1.0
|-- ESP8266AVRISP @ 1.0
|-- ESP8266HTTPClient @ 1.2
|-- ESP8266mDNS @ 1.2
|-- ESP8266WebServer @ 1.0
|-- ESP8266WiFi @ 1.0
|-- SPI @ 1.0