### PR TITLE
Add an option to filter MQTT commands

### DIFF
--- a/examples/P1P2MQTT-bridge/P1P2MQTT-bridge.ino
+++ b/examples/P1P2MQTT-bridge/P1P2MQTT-bridge.ino
@@ -2795,20 +2795,23 @@ void onMqttMessage(char* topic, char* payload, const AsyncMqttClientMessagePrope
   // handle P1P2/W/devicename/bridgename or P1P2/W
   topicCharSpecific('W');
   if ((!strcmp(topic, mqttTopic)) || (!strncmp(topic, mqttTopic, mqttTopicChar + 1) && (topic[ mqttTopicChar + 1 ] == '\0'))) {
-    if (mqttBufferFree < total + 1) {
-      // Serial_print(F("* [ESP] mqttBuffer full (W)"));
-      if ((mqttBufferFullReported < 2) && (mqttBufferFree >= 3)) {
-        mqttBuffer_writeChar('^');
-        mqttBuffer_writeChar('W');
+    if (MQTT_CMD_FILTER != '\0' && tolower(MQTT_payload[0]) != tolower(MQTT_CMD_FILTER)) {
+      delayedPrintfTopicS("MQTT command '%c' not allowed", MQTT_payload[0]);
+    } else {
+      if (mqttBufferFree < total + 1) {
+        // Serial_print(F("* [ESP] mqttBuffer full (W)"));
+        if ((mqttBufferFullReported < 2) && (mqttBufferFree >= 3)) {
+          mqttBuffer_writeChar('^');
+          mqttBuffer_writeChar('W');
+          mqttBuffer_writeChar('\n');
+          mqttBufferFullReported = 2;
+        }
+      } else {
+        if (mqttBufferFullReported > 1) mqttBufferFullReported = 1;
+        mqttBufferWriteString(MQTT_payload, total);
         mqttBuffer_writeChar('\n');
-        mqttBufferFullReported = 2;
       }
-      restoreTopic();
-      return;
     }
-    if (mqttBufferFullReported > 1) mqttBufferFullReported = 1;
-    mqttBufferWriteString(MQTT_payload, total);
-    mqttBuffer_writeChar('\n');
     restoreTopic();
     return;
   }

--- a/examples/P1P2MQTT-bridge/P1P2_Config.h
+++ b/examples/P1P2MQTT-bridge/P1P2_Config.h
@@ -170,6 +170,8 @@
 #define MQTT_RETAIN_SIGNAL false // do not retain informational messages
 #define MQTT_RETAIN_HEX    false // do not retain hex data messages
 
+#define MQTT_CMD_FILTER  '\0'  // Filter incoming MQTT commands (topic W) by the first character. '\0' means no filter.
+
 #define INIT_OUTPUTFILTER 1    // outputfilter determines which parameters to report, can be changed run-time using 'S'/'s' command
                                // 0 all
                                // 1 only changed parameters


### PR DESCRIPTION
## Summary

This is a very small PR that adds an option to filter incoming MQTT commands by **one single command type**.  
By default, the filter is disabled (`'\0'`).  

For example:  
- If the filter is set to `'e'`, only commands `'e'` and `'E'` will be accepted via MQTT.  
- Other commands are ignored.  
- The Telnet behavior remains unchanged.  

This acts as a small extra layer of security, especially useful when **p1p2mqtt is behind a firewall** that only allows the MQTT connection, while Telnet or other connections require separate admin access.


## Implementation notes

- The filter is currently implemented as a compilation variable.  
- Ideally, this parameter should be **saved in EEPROM** so that it can be changed at runtime.  
- Unfortunately, I couldn’t find a clean way to add a new EEPROM parameter that works across **all supported brands**:  
  - Parameter `P35` is already used in some builds but not in others.  
  - The reserved `char[80]` space seems intended for future extensions, but inserting this parameter there would require **renumbering all following parameters**.  

Renumbering raises two concerns:
1. Users may already rely on the existing numbering.  
2. In some cases, parameter positions in the `param*` structures are hardcoded elsewhere, so changing the numbering might break other parts of the code.  


## Why this change

This small feature is meant as a **security improvement** with very limited impact on the existing code.  
It allows tighter control of MQTT commands while leaving Telnet behavior untouched.
