### PR TITLE
Add initial compatibility profile for Daikin ERSQ016AV1 + EKHBRD016ADV1

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ The system can be further identified by generation, which is a single letter or 
 
 Recent Altherma 3 (full-electric and hybrid) systems are generally supported. Version CA, CB, D, and newer are supported. Older versions AA, AB, AC, and BB can only be monitored and can likely not be controlled. Version AD can perhaps be controlled. Some systems (EWYQ, EKH\*) are very limited and can only be monitored.
 
+The ERSQ016AV1 + EKHBRD016ADV1 platform now has an initial manual compatibility profile that promotes confirmed heating/DHW enable bits and suppresses several misleading temperature entities. See [the model note](doc/LogicalFormat/Daikin-protocol-ERSQ016AV1-EKHBRD016ADV1.md).
+
 Not all Rotex R-series systems have the same capability as their Daikin counterpart.
 
 #### Daikin F-series

--- a/doc/KnownIssues.md
+++ b/doc/KnownIssues.md
@@ -24,7 +24,7 @@
  - smart grid / dynamic power limitation
  - web server ([security](Security.md), functionality)
  - logging/setting field settings
- - EKHBRD support
+ - deeper EKHBRD reverse engineering and auto-detection
  - documentation
  - Hitachi support
  - Mitsubishi support

--- a/doc/LogicalFormat/Daikin-protocol-ERSQ016AV1-EKHBRD016ADV1.md
+++ b/doc/LogicalFormat/Daikin-protocol-ERSQ016AV1-EKHBRD016ADV1.md
@@ -1,0 +1,96 @@
+# Daikin ERSQ016AV1 + EKHBRD016ADV1 compatibility notes
+
+This note documents the initial, conservative compatibility profile for the ERSQ016AV1 outdoor unit combined with the EKHBRD016ADV1 indoor/controller platform.
+
+The profile intentionally does not try to fully decode this platform yet. It promotes only the bits that are strongly confirmed and suppresses a few temperature entities that are clearly misleading on this hardware family.
+
+## How to enable the profile
+
+The current implementation uses a manual bridge profile so existing E-series behaviour stays unchanged by default.
+
+- Set bridge parameter `P53` to `1` to enable the `EKHBRD ADV1 profile`
+- Set bridge parameter `P53` back to `0` to return to generic E-series decoding
+- Use `D5` to save the setting to EEPROM if you want it to survive reboot
+
+## Trusted mappings
+
+For this profile, the repeating `0x10` request/response family is treated as the trusted source for:
+
+- `Heating_Enabled`
+- `DHW_Enabled`
+
+Confirmed request matrix:
+
+- `000010010101...` = heat on, DHW on
+- `000010010100...` = heat on, DHW off
+- `000010000101...` = heat off, DHW on
+- `000010000100...` = heat off, DHW off
+
+Confirmed response matrix:
+
+- `4000100100110130...` = heat on, DHW on
+- `4000100100110030...` = heat on, DHW off
+- `4000100000110130...` = heat off, DHW on
+- `4000100000110030...` = heat off, DHW off
+
+Observed bit positions used by the profile:
+
+- request `000010...`: payload byte 0 bit 0 = heating enabled
+- request `000010...`: payload byte 2 bit 0 = DHW enabled
+- response `400010...`: payload byte 0 bit 0 = heating enabled
+- response `400010...`: payload byte 3 bit 0 = DHW enabled
+
+The implementation publishes the named booleans from both the request and response family so either side can refresh the same MQTT topic.
+
+## Sample frames
+
+Steady heat on, DHW on:
+
+- `00001001010130000A0020000000000200004001B1`
+- `4000100100110130000A00200018000000000002000939`
+
+Steady heat on, DHW off:
+
+- `00001001010030000A002000000000020000400131`
+- `4000100100110030000A002000180000000000020009E0`
+
+Steady heat off, DHW on:
+
+- request family prefix: `000010000101...`
+- response family prefix: `4000100000110130...`
+
+Steady heat off, DHW off:
+
+- request family prefix: `000010000100...`
+- response family prefix: `4000100000110030...`
+
+Observed one-shot transition or acknowledge frame:
+
+- `80001001010030000A0020000000000200000001A4`
+
+The current profile documents this frame but does not rely on it for steady-state decoding.
+
+## Intentionally suppressed entities
+
+The generic E-series mapping currently produces clearly implausible values for some water-side temperatures on this platform. To avoid presenting bogus values as trusted sensors, the profile suppresses these named entities:
+
+- `Temperature_R2T_Leaving_Water`
+- `Temperature_R4T_Return_Water`
+- `Temperature_R5T_DHW_Tank`
+- `Temperature_R1T_Leaving_Water`
+- `Temperature_R1T_HP2Gas_Water`
+
+For the same reason, Home Assistant climate entities created by the bridge do not advertise those suppressed temperatures as current-temperature topics when this profile is active.
+
+## What remains uncertain
+
+- The `400011...` family appears to contain live sensor/process data, but the current generic mapping is not reliable enough yet for this model
+- The exact meaning of several water-side temperatures on this platform is still unresolved
+- The `0x80` transition family needs more captures before it should drive state
+- Automatic model detection is not implemented yet for this profile
+
+## Suggested reverse-engineering next steps
+
+- Collect longer logs around heating-only, DHW-only, and compressor-off states
+- Correlate `400011...` bytes with independently measured leaving/return water temperatures
+- Capture restart traffic including `A1` and `B1` model-identification frames to evaluate safe auto-detection

--- a/doc/LogicalFormat/validate_ekhbrd_adv1_frames.py
+++ b/doc/LogicalFormat/validate_ekhbrd_adv1_frames.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+"""Validate the confirmed ERSQ016AV1 + EKHBRD016ADV1 heat/DHW matrix.
+
+Uses the exact captured frames where they are available and short normalized
+fixtures for the remaining matrix states where only the confirmed family prefix
+is currently documented.
+"""
+
+from __future__ import annotations
+
+
+def payload_from_frame(frame: str) -> bytes:
+    data = bytes.fromhex(frame)
+    if len(data) < 5:
+        raise ValueError(f"frame too short: {frame}")
+    return data[3:-1]
+
+
+def decode_request(frame: str) -> tuple[bool, bool]:
+    payload = payload_from_frame(frame)
+    return bool(payload[0] & 0x01), bool(payload[2] & 0x01)
+
+
+def decode_response(frame: str) -> tuple[bool, bool]:
+    payload = payload_from_frame(frame)
+    return bool(payload[0] & 0x01), bool(payload[3] & 0x01)
+
+
+REQUEST_CASES = {
+    "00001001010130000A0020000000000200004001B1": (True, True),
+    "00001001010030000A002000000000020000400131": (True, False),
+    "00001000010100": (False, True),
+    "00001000010000": (False, False),
+}
+
+RESPONSE_CASES = {
+    "4000100100110130000A00200018000000000002000939": (True, True),
+    "4000100100110030000A002000180000000000020009E0": (True, False),
+    "4000100000110100": (False, True),
+    "4000100000110000": (False, False),
+}
+
+ACK_FRAME = "80001001010030000A0020000000000200000001A4"
+
+
+def main() -> int:
+    for frame, expected in REQUEST_CASES.items():
+        actual = decode_request(frame)
+        assert actual == expected, f"request {frame}: expected {expected}, got {actual}"
+
+    for frame, expected in RESPONSE_CASES.items():
+        actual = decode_response(frame)
+        assert actual == expected, f"response {frame}: expected {expected}, got {actual}"
+
+    ack_payload = payload_from_frame(ACK_FRAME)
+    assert ack_payload[0] & 0x01, "ack frame should carry heat=on in payload byte 0 bit 0"
+    assert not (ack_payload[2] & 0x01), "ack frame should carry DHW=off in payload byte 2 bit 0"
+
+    print("ERSQ016AV1/EKHBRD016ADV1 matrix validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/P1P2MQTT-bridge/P1P2MQTT-bridge.ino
+++ b/examples/P1P2MQTT-bridge/P1P2MQTT-bridge.ino
@@ -176,6 +176,7 @@ typedef struct EEPROMSettings {
   char reservedText[ RESERVED_LEN ];
 #ifdef E_SERIES
   byte useR1T; // use R1T instead of R2T
+  byte daikinEkhbrdAdv1Profile;
 #endif /* E_SERIES */
   byte useTZ;
 #define TZ_STRING_LEN 50
@@ -224,6 +225,7 @@ bool factoryReset = 0;
 #define PARAM_EC 45
 #define PARAM_EP 46
 #define PARAM_HA_SETUP 47
+#define PARAM_DAIKIN_EKHBRD_ADV1_PROFILE 53
 #define xstr(s) str(s)
 #define str(s) #s
 #endif /* E_SERIES */
@@ -320,6 +322,7 @@ const char paramName_49[] PROGMEM = "Voltage                 ";
 const char paramName_50[] PROGMEM = "Nr phases (1 or 3)      ";
 const char paramName_51[] PROGMEM = "Power BUH step 1 (kW)   ";
 const char paramName_52[] PROGMEM = "Power BUH step 2 (kW)   ";
+const char paramName_53[] PROGMEM = "EKHBRD ADV1 profile     ";
 #endif /* E_SERIES */
 
 #ifdef F_SERIES
@@ -389,6 +392,7 @@ const char* const paramName[] PROGMEM = {
   paramName_50,
   paramName_51,
   paramName_52,
+  paramName_53,
 #endif /* E_SERIES */
 #ifdef F_SERIES
   paramName_35,
@@ -466,6 +470,7 @@ const paramTypes PROGMEM paramType[] = {
   P_UINT,
   P_INTdiv10,
   P_INTdiv10,
+  P_BOOL,
 #endif /* E_SERIES */
 #ifdef F_SERIES
   P_UINT,
@@ -528,6 +533,7 @@ const int PROGMEM paramSize[] = {
   1,
   4,
   4,
+  1,
   1,
   1,
   1,
@@ -602,6 +608,7 @@ const int PROGMEM paramMax[] = { // non-string: max-value (inclusive); string: m
   3,
   99,
   99,
+  1,
 #endif /* E_SERIES */
 #ifdef F_SERIES
   40,
@@ -670,6 +677,7 @@ char* const PROGMEM paramLocation[] = {
   (char*) &EE.nrPhases,
   (char*) &EE.powerBUH1,
   (char*) &EE.powerBUH2,
+  (char*) &EE.daikinEkhbrdAdv1Profile,
 #endif /* E_SERIES */
 #ifdef F_SERIES
   (char*) &EE.setpointCoolingMin,
@@ -1990,6 +1998,17 @@ void printModifyParam(byte paramNr, bool modParam = false, int32_t newValue = 0,
     pseudo0F = 9;
   }
   if (modParam && (paramNr == PARAM_HA_SETUP)) unSeen();
+  if (modParam && (paramNr == PARAM_DAIKIN_EKHBRD_ADV1_PROFILE)) {
+    unSeen();
+    registerUnseenByte(0x00, 0x00, 0x10, 0);
+    registerUnseenByte(0x00, 0x00, 0x10, 2);
+    registerUnseenByte(0x40, 0x00, 0x10, 0);
+    registerUnseenByte(0x40, 0x00, 0x10, 3);
+    registerUnseenByte(0x40, 0x00, 0x11, 1);
+    registerUnseenByte(0x40, 0x00, 0x11, 3);
+    registerUnseenByte(0x40, 0x00, 0x11, 7);
+    registerUnseenByte(0x40, 0x00, 0x11, 9);
+  }
 #endif /* E_SERIES */
 
 #ifdef F_SERIES
@@ -2162,6 +2181,7 @@ void loadEEPROM() {
     // EE.EE_version = 2;
 #ifdef E_SERIES
     EE.useR1T = 0;
+    EE.daikinEkhbrdAdv1Profile = 0;
 #endif /* E_SERIES */
   }
   if (EE.EE_version < 3) {
@@ -2224,6 +2244,12 @@ void loadEEPROM() {
     EE.EE_version = 9;
     EE.powerBUH1 = 30; // 3.0kW
     EE.powerBUH2 = 60; // 6.0kW
+    saveEEPROM();
+  }
+  if (EE.EE_version < 10) {
+    delayedPrintfTopicS("Upgrade EEPROM_version to 10");
+    EE.EE_version = 10;
+    EE.daikinEkhbrdAdv1Profile = 0;
     saveEEPROM();
   }
 #endif /* E_SERIES */

--- a/examples/P1P2MQTT-bridge/P1P2_ParameterConversion.h
+++ b/examples/P1P2MQTT-bridge/P1P2_ParameterConversion.h
@@ -714,6 +714,7 @@ byte maxOutputFilter = 0;
 uint16_t extraAvailabilityStringLengthMax = 0;
 #ifdef E_SERIES
 uint32_t espUptime030 = 0;
+#define EKHBRD_ADV1_PROFILE_ACTIVE (EE.daikinEkhbrdAdv1Profile)
 #endif /* E_SERIES */
 
 // global variable to maintain info from check* to pub*
@@ -3542,7 +3543,17 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
       case 0x00 : switch (payloadIndex) {
         case    0 : switch (bitNr) {
           case    8 : bcnt = 27; BITBASIS;
-          case    0 : SUBDEVICE("_Mode");
+          case    0 : if (EKHBRD_ADV1_PROFILE_ACTIVE) {
+                        SUBDEVICE("_Mode");
+                        HACONFIG;
+                        CHECKBIT;
+                        KEY("Heating_Enabled");
+                        PUB_CONFIG;
+                        CHECK_ENTITY;
+                        if (haDevice == HA_SENSOR) HADEVICE_BINSENSOR;
+                        value_flag8(packetSrc, packetType, payloadIndex, payload, mqtt_value, bitNr);
+                      }
+                      SUBDEVICE("_Mode");
                       HACONFIG;
                       // CHECK(1) already done by BITBASIS
                       CHECKBIT;
@@ -3593,7 +3604,17 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
         }
         case    2 : switch (bitNr) {
           case    8 : bcnt = 2; BITBASIS;
-          case    0 : SUBDEVICE("_DHW"); KEYBIT_PUB_CONFIG_PUB_ENTITY("DHW_Request_19Q");
+          case    0 : if (EKHBRD_ADV1_PROFILE_ACTIVE) {
+                        SUBDEVICE("_DHW");
+                        HACONFIG;
+                        CHECKBIT;
+                        KEY("DHW_Enabled");
+                        PUB_CONFIG;
+                        CHECK_ENTITY;
+                        if (haDevice == HA_SENSOR) HADEVICE_BINSENSOR;
+                        value_flag8(packetSrc, packetType, payloadIndex, payload, mqtt_value, bitNr);
+                      }
+                      SUBDEVICE("_DHW"); KEYBIT_PUB_CONFIG_PUB_ENTITY("DHW_Request_19Q");
           default   : UNKNOWN_BIT;
         }
         case    7 : return 0;
@@ -3687,7 +3708,7 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                       HADEVICE_CLIMATE;
                       HADEVICE_CLIMATE_TEMPERATURE("S/0/DHW_Setpoint", 30, M.R.DHWsetpointMaxX10 * 0.1, 1)
                       HADEVICE_CLIMATE_MODES("S/1/DHW", "\"off\",\"heat\"", "'0':'off','1':'heat'")
-                      if (M.R.useDHW & 0x01) HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R5T_DHW_Tank")
+                      if ((M.R.useDHW & 0x01) && !EKHBRD_ADV1_PROFILE_ACTIVE) HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R5T_DHW_Tank")
                       HADEVICE_CLIMATE_TEMPERATURE_COMMAND("{{'E360003%04X'|format((value*10)|int)}}");
                       HADEVICE_CLIMATE_MODE_COMMAND_TEMPLATE("{% set modes={'off':0,'heat':1} %}{{'E350040%02X 35003E%02X'|format((modes[value]|int) if value in modes.keys() else 0, (modes[value]|int) if value in modes.keys() else 0)}}");
                       HADEVICE_AVAILABILITY("A\/8\/Control_Function", 1, 0);
@@ -3704,7 +3725,17 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                       pseudo0D = 9;
                     }
                     bcnt = 7; BITBASIS;
-          case  0 : SUBDEVICE("_Unknown");                           HACONFIG;                                              KEYBIT_PUB_CONFIG_PUB_ENTITY("Climate_Active_Q4");
+          case  0 : if (EKHBRD_ADV1_PROFILE_ACTIVE) {
+                      SUBDEVICE("_Mode");
+                      HACONFIG;
+                      CHECKBIT;
+                      KEY("Heating_Enabled");
+                      PUB_CONFIG;
+                      CHECK_ENTITY;
+                      if (haDevice == HA_SENSOR) HADEVICE_BINSENSOR;
+                      value_flag8(packetSrc, packetType, payloadIndex, payload, mqtt_value, bitNr);
+                    }
+                    SUBDEVICE("_Unknown");                           HACONFIG;                                              KEYBIT_PUB_CONFIG_PUB_ENTITY("Climate_Active_Q4");
           default : UNKNOWN_BIT;
         }
         case    1 : switch (bitNr) {
@@ -3736,6 +3767,16 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
         case    3 : switch (bitNr) {
           case    8 : bcnt = 10; BITBASIS;
           case    0 : if (!(M.R.useDHW & 0x02)) return 0;
+                      if (EKHBRD_ADV1_PROFILE_ACTIVE) {
+                        SUBDEVICE("_DHW");
+                        HACONFIG;
+                        CHECKBIT;
+                        KEY("DHW_Enabled");
+                        PUB_CONFIG;
+                        CHECK_ENTITY;
+                        if (haDevice == HA_SENSOR) HADEVICE_BINSENSOR;
+                        value_flag8(packetSrc, packetType, payloadIndex, payload, mqtt_value, bitNr);
+                      }
                       SUBDEVICE("_DHW");                             HACONFIG;                                              KEYBIT_PUB_CONFIG_PUB_ENTITY("DHW"); // follows DHW_Request
           case    4 : if (!(M.R.useDHW & 0x01)) return 0;
                       SUBDEVICE("_Mode");                            HACONFIG;                                              KEYBIT_PUB_CONFIG_PUB_ENTITY("SHC_Tank");
@@ -3821,6 +3862,16 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
       case 0x40 : switch (payloadIndex) {
         case    0 : return 0;
         case    1 : if (EE.useR1T) return 0;
+                    // EKHBRD ADV1 currently reports clearly implausible values on the generic water-temperature mapping.
+                    if (EKHBRD_ADV1_PROFILE_ACTIVE) {
+                      SUBDEVICE("_Sensors");
+                      HACONFIG;
+                      HATEMP1;
+                      CHECK(2);
+                      KEY("Temperature_R2T_Leaving_Water");
+                      DEL_CONFIG;
+                      return 0;
+                    }
                     SUBDEVICE("_Sensors");
                     M.R.LWT = FN_f8_8_LE(payloadPointer)  + EE.R2Toffset * 0.01;
                     HACONFIG;
@@ -3830,6 +3881,15 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                     VALUE_F_L(M.R.LWT, 2); // R2T
         case    2 : return 0;                         // Domestic hot water temperature (on some models)
         case    3 : if (!(M.R.useDHW & 0x01)) return 0;
+                    if (EKHBRD_ADV1_PROFILE_ACTIVE) {
+                      SUBDEVICE("_DHW");
+                      HACONFIG;
+                      HATEMP1;
+                      CHECK(2);
+                      KEY("Temperature_R5T_DHW_Tank");
+                      DEL_CONFIG;
+                      return 0;
+                    }
                     SUBDEVICE("_DHW");
                     HACONFIG;
                     HATEMP1;
@@ -3839,10 +3899,32 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
         case    4 : return 0;                         // Outside air temperature (low res)
         case    5 : SUBDEVICE("_Sensors");                           HACONFIG; HATEMP1;    HYST_F8_8_LE(20)                 KEY2_PUB_CONFIG_CHECK_ENTITY("Temperature_Outside_Unit");                  VALUE_f8_8_LE; // outside temperature outside unit (0.5C) , no RxT reference
         case    6 : return 0;
-        case    7 : SUBDEVICE("_Sensors"); M.R.RWT = FN_f8_8_LE(payloadPointer) + EE.R4Toffset * 0.01;
+        case    7 : if (EKHBRD_ADV1_PROFILE_ACTIVE) {
+                      SUBDEVICE("_Sensors");
+                      HACONFIG;
+                      HATEMP1;
+                      CHECK(2);
+                      KEY("Temperature_R4T_Return_Water");
+                      DEL_CONFIG;
+                      return 0;
+                    }
+                    SUBDEVICE("_Sensors"); M.R.RWT = FN_f8_8_LE(payloadPointer) + EE.R4Toffset * 0.01;
                                                                      HACONFIG; HATEMP1;    HYST_F8_8_LE(20);                KEY2_PUB_CONFIG_CHECK_ENTITY("Temperature_R4T_Return_Water");              VALUE_F_L(M.R.RWT, 2); // R4T
         case    8 : return 0;
-        case    9 : SUBDEVICE("_Sensors");
+        case    9 : if (EKHBRD_ADV1_PROFILE_ACTIVE) {
+                      SUBDEVICE("_Sensors");
+                      HACONFIG;
+                      HATEMP1;
+                      CHECK(2);
+                      if (EE.useR1T) {
+                        KEY("Temperature_R1T_Leaving_Water");
+                      } else {
+                        KEY("Temperature_R1T_HP2Gas_Water");
+                      }
+                      DEL_CONFIG;
+                      return 0;
+                    }
+                    SUBDEVICE("_Sensors");
                     M.R.MWT = FN_f8_8_LE(payloadPointer) + EE.R1Toffset * 0.01;
                     if (EE.useR1T) M.R.LWT = M.R.MWT;
                     HACONFIG;
@@ -4542,9 +4624,9 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                       if (M.R.climateMode & 0x40) { // WD
                         KEY("Deviation_Heating");
                         HADEVICE_CLIMATE_TEMPERATURE("S/0/Deviation_Heating", -10, 10, 1)
-                        if (EE.useR1T) {
+                        if (!EKHBRD_ADV1_PROFILE_ACTIVE && EE.useR1T) {
                           HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R1T_Leaving_Water");
-                        } else {
+                        } else if (!EKHBRD_ADV1_PROFILE_ACTIVE) {
                           HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R2T_Leaving_Water");
                         }
                         if (heatingMode || EE.haSetup || !(M.R.first030 & 0x04)) {
@@ -4562,9 +4644,9 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                       } else { // Abs
                         KEY("Abs_Heating");
                         HADEVICE_CLIMATE_TEMPERATURE("S/0/Abs_Heating", M.R.LWTheatMainMinX10 * 0.1, M.R.LWTheatMainMaxX10 * 0.1, 1)
-                        if (EE.useR1T) {
+                        if (!EKHBRD_ADV1_PROFILE_ACTIVE && EE.useR1T) {
                           HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R1T_Leaving_Water");
-                        } else {
+                        } else if (!EKHBRD_ADV1_PROFILE_ACTIVE) {
                           HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R2T_Leaving_Water");
                         }
                         if (heatingMode || EE.haSetup || !(M.R.first030 & 0x04)) {
@@ -4596,9 +4678,9 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                       if (M.R.climateMode & 0x40) { // WD
                         KEY("Deviation_Cooling");
                         HADEVICE_CLIMATE_TEMPERATURE("S/0/Deviation_Cooling", -10, 10, 1)
-                        if (EE.useR1T) {
+                        if (!EKHBRD_ADV1_PROFILE_ACTIVE && EE.useR1T) {
                           HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R1T_Leaving_Water");
-                        } else {
+                        } else if (!EKHBRD_ADV1_PROFILE_ACTIVE) {
                           HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R2T_Leaving_Water");
                         }
                         if (coolingMode || EE.haSetup || !(M.R.first030 & 0x08)) {
@@ -4617,9 +4699,9 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                       } else { // Abs
                         KEY("Abs_Cooling");
                         HADEVICE_CLIMATE_TEMPERATURE("S/0/Abs_Cooling", M.R.LWTcoolMainMinX10 * 0.1, M.R.LWTcoolMainMaxX10 * 0.1, 1)
-                        if (EE.useR1T) {
+                        if (!EKHBRD_ADV1_PROFILE_ACTIVE && EE.useR1T) {
                           HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R1T_Leaving_Water");
-                        } else {
+                        } else if (!EKHBRD_ADV1_PROFILE_ACTIVE) {
                           HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R2T_Leaving_Water");
                         }
                         if (coolingMode || EE.haSetup || !(M.R.first030 & 0x08)) {
@@ -4655,7 +4737,7 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                         if (M.R.climateMode & 0x40) { // WD
                           KEY("Deviation_Heating_Add");
                           HADEVICE_CLIMATE_TEMPERATURE("S/0/Deviation_Heating_Add", -10, 10, 1)
-                          HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R2T_Leaving_Water")
+                          if (!EKHBRD_ADV1_PROFILE_ACTIVE) HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R2T_Leaving_Water")
                           if (heatingMode || EE.haSetup || !(M.R.first030 & 0x10)) {
                             HADEVICE_CLIMATE_MODES("S/0/Altherma_On", "\"off\",\"heat\"", "'0':'off','1':'heat'")
                             HADEVICE_CLIMATE_MODE_COMMAND_TEMPLATE("{% set modes={'off':0,'heat':1} %}{{'E35002F%02X 350031%02X 35002D%02X'|format((modes[value]|int) if value in modes.keys() else 0, (modes[value]|int) if value in modes.keys() else 0, (modes[value]|int) if value in modes.keys() else 0)}}");
@@ -4672,9 +4754,9 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                         } else { // Abs
                           KEY("Abs_Heating_Add");
                           HADEVICE_CLIMATE_TEMPERATURE("S/0/Abs_Heating_Add", M.R.LWTheatAddMinX10 * 0.1, M.R.LWTheatAddMaxX10 * 0.1, 1)
-                          if (EE.useR1T) {
+                          if (!EKHBRD_ADV1_PROFILE_ACTIVE && EE.useR1T) {
                             HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R1T_Leaving_Water");
-                          } else {
+                          } else if (!EKHBRD_ADV1_PROFILE_ACTIVE) {
                             HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R2T_Leaving_Water");
                           }
                           if (heatingMode || EE.haSetup || !(M.R.first030 & 0x10)) {
@@ -4712,9 +4794,9 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                         if (M.R.climateMode & 0x40) { // WD
                           KEY("Deviation_Cooling_Add");
                           HADEVICE_CLIMATE_TEMPERATURE("S/0/Deviation_Cooling_Add", -10, 10, 1)
-                          if (EE.useR1T) {
+                          if (!EKHBRD_ADV1_PROFILE_ACTIVE && EE.useR1T) {
                             HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R1T_Leaving_Water");
-                          } else {
+                          } else if (!EKHBRD_ADV1_PROFILE_ACTIVE) {
                             HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R2T_Leaving_Water");
                           }
                           if (coolingMode || EE.haSetup || !(M.R.first030 & 0x20)) {
@@ -4734,9 +4816,9 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                         } else { // Abs
                           KEY("Abs_Cooling_Add");
                           HADEVICE_CLIMATE_TEMPERATURE("S/0/Abs_Cooling_Add", M.R.LWTcoolAddMinX10 * 0.1, M.R.LWTcoolAddMaxX10 * 0.1, 1)
-                          if (EE.useR1T) {
+                          if (!EKHBRD_ADV1_PROFILE_ACTIVE && EE.useR1T) {
                             HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R1T_Leaving_Water");
-                          } else {
+                          } else if (!EKHBRD_ADV1_PROFILE_ACTIVE) {
                             HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/1/Temperature_R2T_Leaving_Water");
                           }
                           if (coolingMode || EE.haSetup || !(M.R.first030 & 0x20)) {


### PR DESCRIPTION
## Summary
- add a manual EKHBRD ADV1 compatibility profile so default E-series behaviour stays unchanged
- publish trusted `Heating_Enabled` and `DHW_Enabled` booleans from the confirmed `000010...` / `400010...` frame family
- suppress several clearly implausible water-temperature entities for this profile and stop advertising them as current temperatures in HA climate configs
- document the confirmed mappings, sample frames, and remaining reverse-engineering gaps
- add a small validation script for the confirmed heat/DHW matrix

## How the state mapping was confirmed
The profile uses the repeating `0x10` request/response family as the trusted source on this platform. The confirmed matrix is:

- `000010010101...` = heat on, DHW on
- `000010010100...` = heat on, DHW off
- `000010000101...` = heat off, DHW on
- `000010000100...` = heat off, DHW off
- `4000100100110130...` = heat on, DHW on
- `4000100100110030...` = heat on, DHW off
- `4000100000110130...` = heat off, DHW on
- `4000100000110030...` = heat off, DHW off

Captured transition pair used during validation:

```text
00001001010130000A0020000000000200004001B1
4000100100110130000A00200018000000000002000939
00001001010030000A002000000000020000400131
4000100100110030000A002000180000000000020009E0
80001001010030000A0020000000000200000001A4
```

## What remains uncertain
- the `400011...` sensor/process frame family still needs more reverse engineering on this platform
- automatic profile detection is not implemented yet
- the `0x80` one-shot transition family is documented but not used as the steady-state source

## Why some entities are intentionally hidden
Existing generic mappings expose several water-side temperatures that are clearly implausible on this hardware family, including leaving/return water values near zero while active and unstable DHW tank values. This patch keeps those entities out of the profile instead of presenting them as trusted sensors.