### PR TITLE
Defrost_Active_param15: binary sensor cannot be temperature

### DIFF
--- a/examples/P1P2MQTT-bridge/P1P2_ParameterConversion.h
+++ b/examples/P1P2MQTT-bridge/P1P2_ParameterConversion.h
@@ -2852,7 +2852,7 @@ uint8_t handleParam(byte paramSrc, byte paramPacketType, byte payloadIndex, byte
         case 0x03   : SUBDEVICE("_Mode");    HACONFIG;          CAT_MEASUREMENT; HADEVICE_SENSOR; PARAM_KEY("Fan_RPM"); PARAM_VALUE_s16fan_LE; // EPRA18: 0 or 450+25*value
         case 0x04   :                        HACONFIG;          CAT_MEASUREMENT; HADEVICE_SENSOR; PARAM_KEY("Param15_04"); PARAM_VALUE_s16_LE; // binary ?
         case 0x05   : SUBDEVICE("_Sensors"); HACONFIG; HATEMP1;                  HADEVICE_SENSOR; PARAM_KEY("Temperature_Refrigerant_Q_param15"); PARAM_VALUE_s16div10_LE;
-        case 0x06   :                        HACONFIG; HATEMP1;               HADEVICE_BINSENSOR; PARAM_KEY("Defrost_Active_param15"); PARAM_VALUE_s16div10_LE; // defrost_activity
+        case 0x06   :                        HACONFIG;                           HADEVICE_BINSENSOR; PARAM_KEY("Defrost_Active_param15"); PARAM_VALUE_s16div10_LE; // defrost_activity
         case 0x07   :                        HACONFIG;          CAT_MEASUREMENT; HADEVICE_SENSOR; PARAM_KEY("Param15_07"); PARAM_VALUE_s16_LE; // binary ?
         case 0x08   : SUBDEVICE("_Sensors"); HACONFIG; HATEMP1;                  HADEVICE_SENSOR; PARAM_KEY("Temperature_Outside_param15"); PARAM_VALUE_s16div10_LE;
 


### PR DESCRIPTION
Home Assistant complains:
```
Error 'expected BinarySensorDeviceClass or one of 'battery', 'battery_charging', 'carbon_monoxide', 'cold', 'connectivity', 'door', 'garage_door', 'gas', 'heat', 'light', 'lock', 'moisture', 'motion', 'moving', 'occupancy', 'opening', 'plug', 'power', 'presence', 'problem', 'running', 'safety', 'smoke', 'sound', 'tamper', 'update', 'vibration', 'window' for dictionary value @ data['device_class']' when processing MQTT discovery message topic: 'homeassistant/binary_sensor/bridge0/P1P2MQTT_bridge0_T1_Defrost_Active_param15_1/config', message: '{'availability': [{'topic': 'P1P2/L/P1P2MQTT/bridge0', 'payload_available': 'online', 'payload_not_available': 'offline'}], 'payload_on': 1, 'icon': 'mdi:coolant-temperature', 'availability_mode': 'all', 'state_topic': 'P1P2/P/P1P2MQTT/bridge0/T/1/Defrost_Active_param15', 'unique_id': 'P1P2MQTT_bridge0_T1_Defrost_Active_param15_1', 'payload_off': 0, 'device': {'sw_version': '0.9.58rc23', 'manufacturer': 'Home-CliCK', 'identifiers': ['bridge0_15_param'], 'name': 'bridge0_15_param', 'model': 'P1P2MQTT_bridge'}, 'device_class': 'temperature', 'name': 'Defrost_Active_param15'}'
```