### PR TITLE
MHI heat pump control support

### DIFF
--- a/P1P2MQTT.cpp
+++ b/P1P2MQTT.cpp
@@ -679,18 +679,6 @@ mhiLastCallUs = now;
   w1 = ~(1 << (value & 0x07));
   w2 = ~(1 << ((value >> 3) & 0x07));
   w3 = ~(1 << ((value >> 6) & 0x07));
-  /*
-  Serial.print(F("[+"));
-  Serial.print(dt);
-  Serial.print(F("ms] "));
-  Serial.print(value, HEX);
-  Serial.print(F(" -> w1: "));
-  Serial.print(w1, HEX);
-  Serial.print(F(" w2: "));
-  Serial.print(w2, HEX);
-  Serial.print(F(" w3: "));
-  Serial.println(w3, HEX);
-  */
 }
 
 // Decode 3 MHI wire bytes back to one logical byte; inverse of mhiEncode.
@@ -719,19 +707,6 @@ mhiLastCallUs = now;
   // if (b & 0xF0): error, should be 0 (only 2 bits used in third group)
   if (b & 0xCC) out |= 0x80;
   if (b & 0xAA) out |= 0x40;
-/*
-Serial.print(F("[+"));
-Serial.print(dt);
-Serial.print(F("ms] w1: "));
-Serial.print(w1, HEX);
-Serial.print(F(" w2: "));
-Serial.print(w2, HEX);
-Serial.print(F(" w3: "));
-Serial.print(w3, HEX);
-Serial.print(F(" -> "));
-Serial.println(out, HEX);
-*/
-
   return out;
 }
 #endif

--- a/P1P2MQTT.cpp
+++ b/P1P2MQTT.cpp
@@ -661,15 +661,90 @@ bool P1P2MQTT::writeready(void)
 uint8_t tx_rx_paritycheck;
 uint8_t tx_rx_readbackerror;
 
+#ifdef MHI_SERIES
+static int32_t mhiLastCallUs = 0;
+
+// Encode one logical byte to 3 MHI wire bytes.
+// Each 3-bit group is one-hot encoded: the wire byte has all bits set except the one at position = group value.
+static void mhiEncode(uint8_t value, uint8_t &w1, uint8_t &w2, uint8_t &w3)
+{
+  
+#ifdef S_TIMER
+  int32_t now = (time_millisec);
+// Unsigned math naturally handles the rollover correctly!
+int32_t dt = now - mhiLastCallUs; 
+mhiLastCallUs = now;
+#endif
+
+  w1 = ~(1 << (value & 0x07));
+  w2 = ~(1 << ((value >> 3) & 0x07));
+  w3 = ~(1 << ((value >> 6) & 0x07));
+  /*
+  Serial.print(F("[+"));
+  Serial.print(dt);
+  Serial.print(F("ms] "));
+  Serial.print(value, HEX);
+  Serial.print(F(" -> w1: "));
+  Serial.print(w1, HEX);
+  Serial.print(F(" w2: "));
+  Serial.print(w2, HEX);
+  Serial.print(F(" w3: "));
+  Serial.println(w3, HEX);
+  */
+}
+
+// Decode 3 MHI wire bytes back to one logical byte; inverse of mhiEncode.
+// Masks 0xF0/0xCC/0xAA recover bit 2/1/0 of each 3-bit group index respectively.
+static uint8_t mhiDecode(uint8_t w1, uint8_t w2, uint8_t w3)
+{
+  
+  
+#ifdef S_TIMER
+  int32_t now = (time_millisec);
+// Unsigned math naturally handles the rollover correctly!
+int32_t dt = now - mhiLastCallUs; 
+mhiLastCallUs = now;
+#endif
+
+  uint8_t out = 0;
+  uint8_t b = ~w1;
+  if (b & 0xF0) out |= 0x04;
+  if (b & 0xCC) out |= 0x02;
+  if (b & 0xAA) out |= 0x01;
+  b = ~w2;
+  if (b & 0xF0) out |= 0x20;
+  if (b & 0xCC) out |= 0x10;
+  if (b & 0xAA) out |= 0x08;
+  b = ~w3;
+  // if (b & 0xF0): error, should be 0 (only 2 bits used in third group)
+  if (b & 0xCC) out |= 0x80;
+  if (b & 0xAA) out |= 0x40;
+/*
+Serial.print(F("[+"));
+Serial.print(dt);
+Serial.print(F("ms] w1: "));
+Serial.print(w1, HEX);
+Serial.print(F(" w2: "));
+Serial.print(w2, HEX);
+Serial.print(F(" w3: "));
+Serial.print(w3, HEX);
+Serial.print(F(" -> "));
+Serial.println(out, HEX);
+*/
+
+  return out;
+}
+#endif
+
 void P1P2MQTT::write(uint8_t b)
 #ifdef MHI_SERIES
 {
   if (mhiConvert) {
-    writebyte(~(1<< (b & 0x07)));
-    b >>= 3;
-    writebyte(~(1<< (b & 0x07)));
-    b >>= 3;
-    writebyte(~(1<< (b & 0x07)));
+    uint8_t w1, w2, w3;
+    mhiEncode(b, w1, w2, w3);
+    writebyte(w1);
+    writebyte(w2);
+    writebyte(w3);
   } else {
     writebyte(b);
   }
@@ -792,13 +867,14 @@ ISR(COMPARE_W_INTERRUPT)
       }
       // verify
       // state is even, check bit data (part 2), should be 1, otherwise suspect bus collission
-#ifndef H_SERIES
+#if !defined(H_SERIES) && !defined(MHI_SERIES)
       // for H-link, this results in bus collision errors being detected, as second bit data is not consistently 1, so omit this check on H_SERIES
+      // for MHI_SERIES, bus signal polarity differs from Daikin P1P2: during write, read-back sees LOW when HIGH expected, causing false ERROR_BC
       if (!bit_input) {
         tx_rx_readbackerror |= ERROR_BC;
         SW_SCOPE_LOG_ERROR(sws_count_temp, SWS_EVENT_ERR_BC);
       }
-#endif /* H_SERIES */
+#endif /* H_SERIES, MHI_SERIES */
       tx_bit = bit;
     }
 
@@ -846,7 +922,10 @@ ISR(COMPARE_W_INTERRUPT)
   if (tx_rx_readbackerror) {
     DIGITAL_SET_LED_ERROR;
     // As of version 0.9.22: if a bus collision is suspected (=if a read errors occurs during a write), reduce risk on further collissions by emptying write buffer
+    // MHI_SERIES: do not abort TX buffer — ERROR_BC is suppressed for MHI (bus polarity differs), but other errors may still set tx_rx_readbackerror
+#ifndef MHI_SERIES
     tx_buffer_tail = tx_buffer_head;
+#endif
   }
   // store transmitted byte as it it were received (if buffer space available, and if Echo), and check/store errors
   if (Echo) {
@@ -880,7 +959,14 @@ ISR(COMPARE_W_INTERRUPT)
     if (delay < 2) {
       // if delay=0 or 1, we effectively don't wait and we continue writing!
       // as we are in (silent, high) stop bit time, we set target time at end of stop bit (= next start bit)
+      // MHI: add one extra bit period (2 semibits = 104µs) to include the skipped stop bit,
+      // so each wire byte symbol period = 1248µs as required by the MHI XY bus spec (TD).
+      // Without this, symbols are 1144µs (104µs short), violating the spec.
+#ifdef MHI_SERIES
+      SET_COMPARE_W(GET_COMPARE_W() + Wticks_per_bit_and_semibit + 2 * Wticks_per_semibit);
+#else
       SET_COMPARE_W(GET_COMPARE_W() + Wticks_per_bit_and_semibit);
+#endif
       CONFIG_MATCH_CLEAR();
       CONFIG_CAPTURE_FALLING_EDGE();
       tx_state = 1;
@@ -1290,22 +1376,12 @@ uint8_t  P1P2MQTT::read(void)
 // many thanks to HamdiOlgun for reverse engineering byte encoding in MHI protocol (https://community.openhab.org/t/mitsubishi-heavy-x-y-line-protocol/82898/9)
 {
   if (mhiConvert) {
-    uint8_t b = ~readbyte();
-    uint8_t out = 0x00;
-    if (b & 0xF0) out += 0x04;
-    if (b & 0xCC) out += 0x02;
-    if (b & 0xAA) out += 0x01;
-    if (!available()) return out;
-    b = ~readbyte();
-    if (b & 0xF0) out += 0x20;
-    if (b & 0xCC) out += 0x10;
-    if (b & 0xAA) out += 0x08;
-    if (!available()) return out;
-    b = ~readbyte();
-    // if (b & 0xF0) error, should be 0
-    if (b & 0xCC) out += 0x80;
-    if (b & 0xAA) out += 0x40;
-    return out;
+    uint8_t w1 = readbyte();
+    if (!available()) return mhiDecode(w1, 0xFF, 0xFF);
+    uint8_t w2 = readbyte();
+    if (!available()) return mhiDecode(w1, w2, 0xFF);
+    uint8_t w3 = readbyte();
+    return mhiDecode(w1, w2, w3);
   } else {
     return readbyte();
   }
@@ -1480,7 +1556,7 @@ void P1P2MQTT::writepacket(uint8_t* writebuf, uint8_t l, uint16_t t, uint8_t crc
 // If crc_gen is not zero, adds CRC byte to packet
 // If cs_gen is not zero, adds CS byte to packet
 // Note that t=0 or t=1 increases risk of bus collisions, don't use it if not needed (t<2 will be changed to t=2 in new library).
-  setDelay(t);
+setDelay(t);
 #ifdef MHI_SERIES
   uint8_t cs = 0;
 #elif defined H_SERIES

--- a/examples/P1P2MQTT-bridge/P1P2MQTT-bridge.ino
+++ b/examples/P1P2MQTT-bridge/P1P2MQTT-bridge.ino
@@ -910,6 +910,7 @@ static byte mhiBridgeByte5 = 0xAC;
 char mhiModeWriteTopic[MQTT_TOPIC_LEN];
 char mhiTempWriteTopic[MQTT_TOPIC_LEN];
 char mhiFanWriteTopic[MQTT_TOPIC_LEN];
+char mhiSwingWriteTopic[MQTT_TOPIC_LEN];
 #endif /* MHI_SERIES */
 
 
@@ -1647,12 +1648,16 @@ void mqttSubscribe() {
   strlcat(mhiTempWriteTopic, "/MHI_Temp", MQTT_TOPIC_LEN);
   strlcpy(mhiFanWriteTopic, mqttTopic, MQTT_TOPIC_LEN);
   strlcat(mhiFanWriteTopic, "/MHI_Fan", MQTT_TOPIC_LEN);
+  strlcpy(mhiSwingWriteTopic, mqttTopic, MQTT_TOPIC_LEN);
+  strlcat(mhiSwingWriteTopic, "/MHI_Swing", MQTT_TOPIC_LEN);
   result = mqttClient.subscribe(mhiModeWriteTopic, MQTT_QOS_CONTROL);
   printfTopicS("Subscribed to %s result %d", mhiModeWriteTopic, result);
   result = mqttClient.subscribe(mhiTempWriteTopic, MQTT_QOS_CONTROL);
   printfTopicS("Subscribed to %s result %d", mhiTempWriteTopic, result);
   result = mqttClient.subscribe(mhiFanWriteTopic, MQTT_QOS_CONTROL);
   printfTopicS("Subscribed to %s result %d", mhiFanWriteTopic, result);
+  result = mqttClient.subscribe(mhiSwingWriteTopic, MQTT_QOS_CONTROL);
+  printfTopicS("Subscribed to %s result %d", mhiSwingWriteTopic, result);
 #endif /* MHI_SERIES */
 
   // subscribe to homeassistant/status
@@ -3079,6 +3084,34 @@ void onMqttMessage(char* topic, char* payload, const AsyncMqttClientMessagePrope
     else if (!strcmp(MQTT_payload, "high"))    fanSpeed = 2;
     else { restoreTopic(); return; }
     mhiBridgeByte4 = 0x88 | fanSpeed | curVane;
+    char mhiCmd[24];
+    snprintf(mhiCmd, sizeof(mhiCmd), "MH %02X %02X %02X", mhiBridgeByte3, mhiBridgeByte4, mhiBridgeByte5);
+    Serial.print(F(SERIAL_MAGICSTRING));
+    Serial.println(mhiCmd);
+    restoreTopic();
+    return;
+  }
+  // MHI AC control: swing/vane mode
+  // "swing"      → byte3 bit6=1, byte4 vane bits unchanged
+  // "top"        → byte3 bit6=0, byte4 bits5-4=00
+  // "mid_top"    → byte3 bit6=0, byte4 bits5-4=01
+  // "mid_bottom" → byte3 bit6=0, byte4 bits5-4=10
+  // "bottom"     → byte3 bit6=0, byte4 bits5-4=11
+  if (!strcmp(topic, mhiSwingWriteTopic)) {
+    byte curFan = (mhiBridgeByte4 & ~0x30);           // preserve all bits except vane bits5-4
+    if (!strcmp(MQTT_payload, "swing")) {
+      mhiBridgeByte3 |= 0x40;                          // set swing bit
+      // vane bits ignored by AC when swing active; leave byte4 unchanged
+    } else {
+      mhiBridgeByte3 &= ~0x40;                         // clear swing bit
+      byte vane;
+      if      (!strcmp(MQTT_payload, "top"))        vane = 0x00;
+      else if (!strcmp(MQTT_payload, "mid_top"))    vane = 0x10;
+      else if (!strcmp(MQTT_payload, "mid_bottom")) vane = 0x20;
+      else if (!strcmp(MQTT_payload, "bottom"))     vane = 0x30;
+      else { restoreTopic(); return; }
+      mhiBridgeByte4 = curFan | vane;
+    }
     char mhiCmd[24];
     snprintf(mhiCmd, sizeof(mhiCmd), "MH %02X %02X %02X", mhiBridgeByte3, mhiBridgeByte4, mhiBridgeByte5);
     Serial.print(F(SERIAL_MAGICSTRING));

--- a/examples/P1P2MQTT-bridge/P1P2MQTT-bridge.ino
+++ b/examples/P1P2MQTT-bridge/P1P2MQTT-bridge.ino
@@ -899,6 +899,19 @@ bool shouldSaveConfig = false;
 //static byte cs_gen = CS_GEN;
 //#endif /* MHI_SERIES */
 
+#ifdef MHI_SERIES
+// Bridge-side MHI write state — tracks last sent/received AC state bytes
+// byte3: mode/power/swing  (default: auto on, no swing = 0xA3)
+// byte4: fan speed/vane    (default: fan L1, mid-top vane  = 0x98)
+// byte5: setpoint temp     (default: 22.0°C = 0xAC)
+static byte mhiBridgeByte3 = 0xA3;
+static byte mhiBridgeByte4 = 0x98;
+static byte mhiBridgeByte5 = 0xAC;
+char mhiModeWriteTopic[MQTT_TOPIC_LEN];
+char mhiTempWriteTopic[MQTT_TOPIC_LEN];
+char mhiFanWriteTopic[MQTT_TOPIC_LEN];
+#endif /* MHI_SERIES */
+
 
 #ifdef AVRISP
 const uint16_t avrisp_port = 328;
@@ -1624,6 +1637,23 @@ void mqttSubscribe() {
   printfTopicS("Subscribed to %s result %d", mqttTopic, result);
 
   restoreTopic();
+
+#ifdef MHI_SERIES
+  // subscribe to MHI per-parameter control topics (mode / temperature / fan)
+  topicCharSpecific('W');
+  strlcpy(mhiModeWriteTopic, mqttTopic, MQTT_TOPIC_LEN);
+  strlcat(mhiModeWriteTopic, "/MHI_Mode", MQTT_TOPIC_LEN);
+  strlcpy(mhiTempWriteTopic, mqttTopic, MQTT_TOPIC_LEN);
+  strlcat(mhiTempWriteTopic, "/MHI_Temp", MQTT_TOPIC_LEN);
+  strlcpy(mhiFanWriteTopic, mqttTopic, MQTT_TOPIC_LEN);
+  strlcat(mhiFanWriteTopic, "/MHI_Fan", MQTT_TOPIC_LEN);
+  result = mqttClient.subscribe(mhiModeWriteTopic, MQTT_QOS_CONTROL);
+  printfTopicS("Subscribed to %s result %d", mhiModeWriteTopic, result);
+  result = mqttClient.subscribe(mhiTempWriteTopic, MQTT_QOS_CONTROL);
+  printfTopicS("Subscribed to %s result %d", mhiTempWriteTopic, result);
+  result = mqttClient.subscribe(mhiFanWriteTopic, MQTT_QOS_CONTROL);
+  printfTopicS("Subscribed to %s result %d", mhiFanWriteTopic, result);
+#endif /* MHI_SERIES */
 
   // subscribe to homeassistant/status
   result = mqttClient.subscribe("homeassistant/status", MQTT_QOS_CONTROL);
@@ -3002,6 +3032,62 @@ void onMqttMessage(char* topic, char* payload, const AsyncMqttClientMessagePrope
     return;
   }
 
+#ifdef MHI_SERIES
+  // MHI AC control: mode command  (off / auto / cool / heat / dry / fan_only)
+  if (!strcmp(topic, mhiModeWriteTopic)) {
+    byte newByte3 = mhiBridgeByte3;
+    if (!strcmp(MQTT_payload, "off")) {
+      newByte3 &= ~0x01;                              // clear power bit, keep rest
+    } else {
+      byte modeVal = 0;
+      if      (!strcmp(MQTT_payload, "auto"))     modeVal = 0;
+      else if (!strcmp(MQTT_payload, "dry"))       modeVal = 1;
+      else if (!strcmp(MQTT_payload, "cool"))      modeVal = 2;
+      else if (!strcmp(MQTT_payload, "fan_only"))  modeVal = 3;
+      else if (!strcmp(MQTT_payload, "heat"))      modeVal = 4;
+      else { restoreTopic(); return; }
+      // bits 1,5,6,7 fixed (0xA2 base); bit 0=power; bits 2-4=mode
+      newByte3 = (newByte3 & 0xE2) | 0x01 | (modeVal << 2);
+    }
+    mhiBridgeByte3 = newByte3;
+    char mhiCmd[24];
+    snprintf(mhiCmd, sizeof(mhiCmd), "MH %02X %02X %02X", mhiBridgeByte3, mhiBridgeByte4, mhiBridgeByte5);
+    Serial.print(F(SERIAL_MAGICSTRING));
+    Serial.println(mhiCmd);
+    restoreTopic();
+    return;
+  }
+  // MHI AC control: temperature setpoint (float string, e.g. "22.5")
+  if (!strcmp(topic, mhiTempWriteTopic)) {
+    float tempVal;
+    if (sscanf(MQTT_payload, "%f", &tempVal) == 1) {
+      mhiBridgeByte5 = (byte)((int)(tempVal * 2.0f + 0.5f) + 0x80);
+      char mhiCmd[24];
+      snprintf(mhiCmd, sizeof(mhiCmd), "MH %02X %02X %02X", mhiBridgeByte3, mhiBridgeByte4, mhiBridgeByte5);
+      Serial.print(F(SERIAL_MAGICSTRING));
+      Serial.println(mhiCmd);
+    }
+    restoreTopic();
+    return;
+  }
+  // MHI AC control: fan mode (auto / low / medium / high)
+  if (!strcmp(topic, mhiFanWriteTopic)) {
+    byte curVane = (mhiBridgeByte4 & 0x30);           // preserve bits 4-5 (vane position)
+    byte fanSpeed;
+    if      (!strcmp(MQTT_payload, "auto") || !strcmp(MQTT_payload, "low"))  fanSpeed = 0;
+    else if (!strcmp(MQTT_payload, "medium"))  fanSpeed = 1;
+    else if (!strcmp(MQTT_payload, "high"))    fanSpeed = 2;
+    else { restoreTopic(); return; }
+    mhiBridgeByte4 = 0x88 | fanSpeed | curVane;
+    char mhiCmd[24];
+    snprintf(mhiCmd, sizeof(mhiCmd), "MH %02X %02X %02X", mhiBridgeByte3, mhiBridgeByte4, mhiBridgeByte5);
+    Serial.print(F(SERIAL_MAGICSTRING));
+    Serial.println(mhiCmd);
+    restoreTopic();
+    return;
+  }
+#endif /* MHI_SERIES */
+
   // unknown topic received
   delayedPrintfTopicS("Unknown MQTT topic received %s payload %s", topic, MQTT_payload);
   restoreTopic();
@@ -3584,6 +3670,17 @@ void process_for_mqtt(byte* rb, int n) {
 #ifdef EF_SERIES
     if (n == 3) bytes2keyvalue(rb[0], rb[1], rb[2], EMPTY_PAYLOAD, rb + 3);
 #endif /* EF_SERIES */
+#ifdef MHI_SERIES
+    // Sync bridge write-state from the master's poll frame (packetSrc 0x00, FDUM poll).
+    // rb[0]=0x00 = master→FDUM; rb[2]=byte3, rb[3]=byte4, rb[4]=byte5.
+    // This keeps mhiBridgeByte* in sync when an external device (wall remote,
+    // physical RC-E5) changes the AC state without going through the bridge.
+    if ((rb[0] == 0x00) && (n >= 5)) {
+      mhiBridgeByte3 = rb[2];
+      mhiBridgeByte4 = rb[3];
+      mhiBridgeByte5 = rb[4];
+    }
+#endif /* MHI_SERIES */
 #ifdef MHI_SERIES
     for (byte i = 1; i < n; i++)
 #else /* MHI_SERIES */

--- a/examples/P1P2MQTT-bridge/P1P2_ParameterConversion.h
+++ b/examples/P1P2MQTT-bridge/P1P2_ParameterConversion.h
@@ -310,6 +310,21 @@ char timeString2[23] = "Mo 2000-00-00 00:00:00"; // reads time from packet type 
     "\"fan_mode_cmd_tpl\":\"{{ value }}\"," \
     , mhiFanWriteTopic); \
 }
+// swing_mode_stat_t publishes "swing","top","mid_top","mid_bottom","bottom" directly
+#define MHI_HADEVICE_CLIMATE_SWING_MODES(swing_stat_topic) { \
+  topicCharSpecific('P'); \
+  HACONFIGMESSAGE_ADD( \
+    "\"swing_mode_stat_t\":\"%s/%s\"," \
+    "\"swing_mode_stat_tpl\":\"{{ value }}\"," \
+    "\"swing_modes\":[\"swing\",\"top\",\"mid_top\",\"mid_bottom\",\"bottom\"]," \
+    , mqttTopic, swing_stat_topic); \
+}
+#define MHI_HADEVICE_CLIMATE_SWING_COMMAND() { \
+  HACONFIGMESSAGE_ADD( \
+    "\"swing_mode_cmd_t\":\"%s\"," \
+    "\"swing_mode_cmd_tpl\":\"{{ value }}\"," \
+    , mhiSwingWriteTopic); \
+}
 #endif /* MHI_SERIES */
 
 //==================================================================================================================
@@ -6273,6 +6288,8 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                       MHI_HADEVICE_CLIMATE_MODE_COMMAND();
                       MHI_HADEVICE_CLIMATE_TEMP_COMMAND();
                       MHI_HADEVICE_CLIMATE_FAN_COMMAND();
+                      MHI_HADEVICE_CLIMATE_SWING_MODES("S/0/MHI_Swing");
+                      MHI_HADEVICE_CLIMATE_SWING_COMMAND();
                       CAT_SETTING;
                       KEY("MHI_Climate");
                       printfTopicS("MHI: publishing climate HA config pb=0x%02X mLen=%i", pb, haConfigMessageLength);
@@ -6283,6 +6300,18 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                     KEY("MHI_Mode");
                     snprintf(mqtt_value, MQTT_VALUE_LEN, "%s", modeStr);
                     publishEntityByte(packetSrc, packetType, payloadIndex, payload, mqtt_value, 1);
+                    // Publish swing/vane state to S/0/MHI_Swing
+                    // Derived from byte3 bit6 (swing flag) and byte4 bits5-4 (vane position)
+                    { byte vane = (payload[payloadIndex + 1] >> 4) & 0x03;
+                      const char* swingStr = (pb & 0x40)  ? "swing"
+                                           : (vane == 0)  ? "top"
+                                           : (vane == 1)  ? "mid_top"
+                                           : (vane == 2)  ? "mid_bottom"
+                                           :                "bottom";
+                      KEY("MHI_Swing");
+                      snprintf(mqtt_value, MQTT_VALUE_LEN, "%s", swingStr);
+                      clientPublish(mqtt_value, haQos);
+                    }
                   }
                   BITBASIS;
         case  6 :                                                                                                           KEYBIT_PUB_CONFIG_PUB_ENTITY("Swing");

--- a/examples/P1P2MQTT-bridge/P1P2_ParameterConversion.h
+++ b/examples/P1P2MQTT-bridge/P1P2_ParameterConversion.h
@@ -270,6 +270,49 @@ char timeString2[23] = "Mo 2000-00-00 00:00:00"; // reads time from packet type 
 }
 
 //==================================================================================================================
+// MHI-specific climate macros — write topics point to bridge-side state-merging handlers
+
+#ifdef MHI_SERIES
+// mode_stat_t publishes string values directly ("off","auto","cool","heat","dry","fan_only")
+#define MHI_HADEVICE_CLIMATE_MODES(mode_stat_topic) { \
+  topicCharSpecific('P'); \
+  HACONFIGMESSAGE_ADD( \
+    "\"mode_stat_t\":\"%s/%s\"," \
+    "\"mode_stat_tpl\":\"{{ value }}\"," \
+    "\"modes\":[\"off\",\"auto\",\"cool\",\"heat\",\"dry\",\"fan_only\"]," \
+    , mqttTopic, mode_stat_topic); \
+}
+// fan_mode_stat_t publishes numeric 1/2/3 — template converts to HA strings
+#define MHI_HADEVICE_CLIMATE_FAN_MODES(fan_stat_topic) { \
+  topicCharSpecific('P'); \
+  HACONFIGMESSAGE_ADD( \
+    "\"fan_mode_stat_t\":\"%s/%s\"," \
+    "\"fan_mode_stat_tpl\":\"{%% set m={'1':'low','2':'medium','3':'high'} %%}{{ m[value] if value in m else 'low' }}\"," \
+    "\"fan_modes\":[\"low\",\"medium\",\"high\"]," \
+    , mqttTopic, fan_stat_topic); \
+}
+// Command topics use the bridge-side per-parameter write topics (defined in P1P2MQTT-bridge.ino)
+#define MHI_HADEVICE_CLIMATE_MODE_COMMAND() { \
+  HACONFIGMESSAGE_ADD( \
+    "\"mode_cmd_t\":\"%s\"," \
+    "\"mode_cmd_tpl\":\"{{ value }}\"," \
+    , mhiModeWriteTopic); \
+}
+#define MHI_HADEVICE_CLIMATE_TEMP_COMMAND() { \
+  HACONFIGMESSAGE_ADD( \
+    "\"temp_cmd_t\":\"%s\"," \
+    "\"temp_cmd_tpl\":\"{{ value }}\"," \
+    , mhiTempWriteTopic); \
+}
+#define MHI_HADEVICE_CLIMATE_FAN_COMMAND() { \
+  HACONFIGMESSAGE_ADD( \
+    "\"fan_mode_cmd_t\":\"%s\"," \
+    "\"fan_mode_cmd_tpl\":\"{{ value }}\"," \
+    , mhiFanWriteTopic); \
+}
+#endif /* MHI_SERIES */
+
+//==================================================================================================================
 
 #define HADEVICE_AVAILABILITY(availability_topic, on_value, off_value) { \
   topicCharSpecific('P'); \
@@ -1451,6 +1494,7 @@ void checkSize() {
   }
 #endif /* E_SERIES */
   for (uint16_t i = 1; i < PCKTP_ARR_SZ; i++) {
+    if (bytestart[i - 1] + nr_bytes[i - 1] >= sizePayloadByteVal) break; // stop at last valid entry
     if (bytestart[i] != bytestart[i - 1] + nr_bytes[i - 1]) printfTopicS("bytestart error i %i bytestart[i] 0x%04X bytestart[i-1] 0x%04X nr_bytes[i-1]", i, bytestart[i], bytestart[i-1], nr_bytes[i-1]);
   }
 }
@@ -6207,6 +6251,39 @@ byte bytesbits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte pa
                     case 0x80 ... 0x81 : bcnt = 0x08 + (packetSrc - 0x80); break;
                     default            : /* should not happen */; break;
                   }
+                  // Publish combined MHI_Mode string and HA CLIMATE entity for src 0x00 (master→FDUM)
+                  if (packetSrc == 0x00) {
+                    byte pb = payload[payloadIndex];
+                    const char* modeStr = !(pb & 0x01)            ? "off"
+                                        : ((pb >> 2) & 0x07) == 0 ? "auto"
+                                        : ((pb >> 2) & 0x07) == 1 ? "dry"
+                                        : ((pb >> 2) & 0x07) == 2 ? "cool"
+                                        : ((pb >> 2) & 0x07) == 3 ? "fan_only"
+                                        :                            "heat";
+                    HADEVICE_CLIMATE;
+                    QOS_CLIMATE;
+                    HATEMP1;
+                    CHECK(1);
+                    printfTopicS("MHI: src00 pi=%i pb=0x%02X pubHa=%d haCfg=%d", payloadIndex, pb, pubHa ? 1 : 0, haConfig);
+                    if (pubHa) {
+                      MHI_HADEVICE_CLIMATE_MODES("S/0/MHI_Mode");
+                      HADEVICE_CLIMATE_TEMPERATURE("S/0/Set_Temp", 16, 30, 0.5);
+                      HADEVICE_CLIMATE_TEMPERATURE_CURRENT("T/2/RC_Indoor_Temp");
+                      MHI_HADEVICE_CLIMATE_FAN_MODES("S/0/Fan_Speed");
+                      MHI_HADEVICE_CLIMATE_MODE_COMMAND();
+                      MHI_HADEVICE_CLIMATE_TEMP_COMMAND();
+                      MHI_HADEVICE_CLIMATE_FAN_COMMAND();
+                      CAT_SETTING;
+                      KEY("MHI_Climate");
+                      printfTopicS("MHI: publishing climate HA config pb=0x%02X mLen=%i", pb, haConfigMessageLength);
+                      PUB_CONFIG;
+                    }
+                    // Publish combined mode string to S/0/MHI_Mode
+                    // Use publishEntityByte so payloadByteSeen is set, preventing config re-publish every frame
+                    KEY("MHI_Mode");
+                    snprintf(mqtt_value, MQTT_VALUE_LEN, "%s", modeStr);
+                    publishEntityByte(packetSrc, packetType, payloadIndex, payload, mqtt_value, 1);
+                  }
                   BITBASIS;
         case  6 :                                                                                                           KEYBIT_PUB_CONFIG_PUB_ENTITY("Swing");
         case  3 ... 4 : // only call 3 and/or 4 in new method; so need to fall-through here:
@@ -6270,6 +6347,11 @@ void unSeen() {
   UNSEEN_BYTE_00_10_19_CLIMATE_DHW;
   UNSEEN_BYTE_40_0F_10_HEATING_ONLY;
 #endif /* E_SERIES */
+#ifdef MHI_SERIES
+  // Mark mode/power/swing byte (payloadIndex 1, packetSrc 0x00) as unseen
+  // so the MHI_Climate HA discovery config is republished on HA reconnect / MQTT Rebuild
+  registerUnseenByte(0x00, 0x00, 0x00, 1);
+#endif /* MHI_SERIES */
 }
 
 byte bits2keyvalue(byte packetSrc, byte packetDst, byte packetType, byte payloadIndex, byte* payload, byte j) {

--- a/examples/P1P2Monitor/P1P2Config.h
+++ b/examples/P1P2Monitor/P1P2Config.h
@@ -215,6 +215,7 @@
 #ifdef MHI_SERIES
 #define INIT_BRAND 4
 #define INIT_MODEL 0
+#define MHI_RC_DELAY             250  // ms delay before sending RC-E5 reply (per spec) - 250ms for A slave, 350 for B slave
 #endif
 
 #ifdef EF_SERIES

--- a/examples/P1P2Monitor/P1P2Monitor.ino
+++ b/examples/P1P2Monitor/P1P2Monitor.ino
@@ -1,5 +1,5 @@
 /* P1P2Monitor: monitor and control program for HBS such as P1/P2 bus on many Daikin systems.
- *              Mitsubishi Heavy Industries (MHI) X-Y line protocol: no control yet
+ *              Mitsubishi Heavy Industries (MHI) X-Y line protocol: RC-E5 emulation for AC control
  *
  *              Reads the P1/P2 bus using the P1P2MQTT library, and outputs raw hex data and verbose output over serial.
  *              A few additional parameters are added in raw hex data as so-called pseudo-packets (packet type 0x08 and 0x09).
@@ -108,6 +108,21 @@
 
 #ifdef MHI_SERIES
 static byte mhiFormat = INIT_MHI_FORMAT;
+static bool mhiStateInitialized = false; // true after user sets via 'A' command (locks state)
+static byte mhiStateByte3 = 0;  // user-requested: mode/power/swing
+static byte mhiStateByte4 = 0;  // user-requested: fan speed/vane
+static byte mhiStateByte5 = 0;  // user-requested: setpoint temperature
+static byte mhiPrevByte3 = 0;   // previous 1FF7 byte3 — used to detect external state changes
+static byte mhiPrevByte4 = 0;   // previous 1FF7 byte4
+static byte mhiPrevByte5 = 0;   // previous 1FF7 byte5
+// RC-E5 absence detection: only reply after MHI_RC_THRESHOLD consecutive unanswered 1FF7 polls.
+// -1 = not yet started, 0..MHI_RC_THRESHOLD-1 = counting, MHI_RC_THRESHOLD = absent (we reply)
+#define MHI_RC_THRESHOLD 3
+static int8_t mhiRcAbsentCnt = -1;
+// Set after publishing a 9FF7 reply; causes the next 9FF7 seen on the bus to be skipped
+// (it is our own echo) and then cleared, preventing false "RC-E5 detected" triggering.
+static bool mhiSkipNext9FF7 = false;
+static byte mhiDataBlock[9];    // data block bytes 7-15 — initialized from first 0x1FF7
 #endif /* MHI_SERIES */
 static byte brand = INIT_BRAND;
 static byte model = INIT_MODEL;
@@ -1203,14 +1218,41 @@ byte writeBudget_prev = 0;
                       Serial_println(cs_gen);
                       break;
             case 'm':
-            case 'M': Serial_print(F("* MHI format translation 3-to-1 on/off "));
-                      if (scanint(RSp, temp) == 1) {
-                        mhiFormat = temp ? 1 : 0;
-                        P1P2MQTT.setMHI(mhiFormat);
-                        EEPROM.update(EEPROM_ADDRESS_MHI_FORMAT, mhiFormat);
-                        Serial_print(F("set to "));
+            case 'M': if (*RSp == 'H' || *RSp == 'h') {
+                        // MH <byte3> <byte4> <byte5> — Set MHI AC state (hex, space-separated)
+                        // byte3: mode/power/swing  e.g. AA=cooling off, AB=cooling on, EF=fan+swing on
+                        // byte4: fan speed/vane    e.g. 98=L1 mid-top, 99=L2, 9A=L3
+                        // byte5: setpoint temp     e.g. AC=22.0C, AD=22.5C, AE=23.0C (formula: (val-0x80)/2.0)
+                        RSp++; // skip 'H'
+                        uint16_t b3, b4, b5;
+                        Serial_print(F("* MHI AC state "));
+                        if (sscanf(RSp, (const char*) "%4x %4x %4x", &b3, &b4, &b5) == 3) {
+                          mhiStateByte3 = (byte)(b3 & 0xFF);
+                          mhiStateByte4 = (byte)(b4 & 0xFF);
+                          mhiStateByte5 = (byte)(b5 & 0xFF);
+                          mhiStateInitialized = true;
+                          Serial_print(F("set to "));
+                        }
+                        if (mhiStateInitialized) {
+                          Serial_print(F("byte3=0x")); if (mhiStateByte3 < 0x10) Serial_print('0'); Serial_print(mhiStateByte3, HEX);
+                          Serial_print(F(" byte4=0x")); if (mhiStateByte4 < 0x10) Serial_print('0'); Serial_print(mhiStateByte4, HEX);
+                          Serial_print(F(" byte5=0x")); if (mhiStateByte5 < 0x10) Serial_print('0'); Serial_println(mhiStateByte5, HEX);
+                        } else {
+                          Serial_println(F("(not yet initialized — waiting for first 0x1FF7)"));
+                        }
+                        Serial_println(F("* byte3: AA=cooling/off, AB=cooling/on, A3=auto/on, EF=fan+swing/on, AF=fan/on, E3=auto+swing/on"));
+                        Serial_println(F("* byte4: 88=L1top, 98=L1mid-top, A8=L1mid-bot, B8=L1bot, 99=L2, 9A=L3"));
+                        Serial_println(F("* byte5: AC=22.0C, AD=22.5C, AE=23.0C, A8=20.0C, B4=26.0C (formula: (val-0x80)/2.0)"));
+                      } else {
+                        Serial_print(F("* MHI format translation 3-to-1 on/off "));
+                        if (scanint(RSp, temp) == 1) {
+                          mhiFormat = temp ? 1 : 0;
+                          P1P2MQTT.setMHI(mhiFormat);
+                          EEPROM.update(EEPROM_ADDRESS_MHI_FORMAT, mhiFormat);
+                          Serial_print(F("set to "));
+                        }
+                        Serial_println(mhiFormat);
                       }
-                      Serial_println(mhiFormat);
                       break;
 #endif /* MHI_SERIES */
             case 'v':
@@ -2725,6 +2767,80 @@ For FDYQ-like systems, try using the same commands with packet type 38 replaced 
       }
     }
     Serial_println();
+
+
+    
+#ifdef MHI_SERIES
+
+    // MHI RC-E5 absence detection: if a 9FF7 reply is seen (even corrupted, which happens
+    // when we collide with a real RC-E5), a physical RC-E5 is present — stop emulating.
+    // If mhiSkipNext9FF7 is set, the message is our own echo — skip it and clear the flag.
+    if ((nread >= 2) && (RB[0] == 0x9F) && (RB[1] == 0xF7) && (delta < MHI_RC_DELAY + 10)) {
+      if (mhiSkipNext9FF7) {
+        mhiSkipNext9FF7 = false;
+      } else {
+        if (mhiRcAbsentCnt == MHI_RC_THRESHOLD) {
+          Serial_println(F("* MHI RC-E5 detected — stopping emulation"));
+        }
+        mhiRcAbsentCnt = 0;
+      }
+    }
+    // MHI RC-E5 emulation: act as slave, reply to master polls addressed to 0x1FF7.
+    // Only reply after MHI_RC_THRESHOLD consecutive unanswered polls (no real RC-E5 present).
+    // State is initialised from the first 0x1FF7 frame (always an echo of actual AC state).
+    // Subsequent replies echo back the same values unless changed via the 'A' command.
+    // Checksum (byte 16) is appended by the library (cs_gen=1).
+    if ((nread >= 15) && (RB[0] == 0x1F) && (RB[1] == 0xF7)) {
+      if (mhiRcAbsentCnt < MHI_RC_THRESHOLD) {
+        // still counting — increment and wait
+        if (mhiRcAbsentCnt < 0) mhiRcAbsentCnt = 0;
+        mhiRcAbsentCnt++;
+        if (mhiRcAbsentCnt == MHI_RC_THRESHOLD) {
+          Serial_println(F("* No RC-E5 detected — starting MHI emulation"));
+        }
+      } else if (!readError) {
+        // RC-E5 confirmed absent — build and send reply.
+        // Apply user-requested state bytes only when the 1FF7 state is unchanged since last
+        // poll (i.e. no other party on the bus changed something in between).
+        // If the master's state changed externally, echo it this cycle and let the user
+        // override take effect once the state has stabilised.
+        bool stateUnchanged = (RB[2] == mhiPrevByte3) &&
+                              (RB[3] == mhiPrevByte4) &&
+                              (RB[4] == mhiPrevByte5);
+        bool applyOverride  = mhiStateInitialized && stateUnchanged;
+        mhiPrevByte3 = RB[2];   // record this poll as the new baseline
+        mhiPrevByte4 = RB[3];
+        mhiPrevByte5 = RB[4];
+        if (!stateUnchanged) {
+          // External change detected — reset pending override to current bus state
+          mhiStateByte3 = RB[2];
+          mhiStateByte4 = RB[3];
+          mhiStateByte5 = RB[4];
+          mhiStateInitialized = false;
+        }
+        WB[0] = 0x9F;                                    // RC-E5 reply address high byte
+        WB[1] = 0xF7;                                    // RC-E5 reply address low byte
+        WB[2] = applyOverride ? mhiStateByte3 : RB[2];  // override or echo: mode/power/swing
+        WB[3] = applyOverride ? mhiStateByte4 : RB[3];  // override or echo: fan speed/vane
+        WB[4] = applyOverride ? mhiStateByte5 : RB[4];  // override or echo: setpoint temperature
+        WB[5] = 0xFF;           // byte 6: no sensor on RC-E5 (per spec)
+        for (byte i = 6; i < 15; i++) WB[i] = RB[i]; // echo data block (bytes 7–15)
+
+        
+        if (P1P2MQTT.writeready()) {
+          P1P2MQTT.writepacket(WB, 15, MHI_RC_DELAY, cs_gen);
+          mhiSkipNext9FF7 = true;  // skip the bus echo of our own reply
+        } else {
+          Serial_println(F("* Refusing to write MHI RC-E5 reply while previous write wasn't finished"));
+          if (writeRefusedBusy < 0xFF) writeRefusedBusy++;
+        }
+        
+
+        
+      }
+    }
+
+#endif /* MHI_SERIES */
   }
 #ifdef PSEUDO_PACKETS
   if (pseudo0E > 4) {

--- a/examples/P1P2Monitor/P1P2Monitor.ino
+++ b/examples/P1P2Monitor/P1P2Monitor.ino
@@ -115,10 +115,6 @@ static byte mhiStateByte5 = 0;  // user-requested: setpoint temperature
 static byte mhiPrevByte3 = 0;   // previous 1FF7 byte3 — used to detect external state changes
 static byte mhiPrevByte4 = 0;   // previous 1FF7 byte4
 static byte mhiPrevByte5 = 0;   // previous 1FF7 byte5
-// RC-E5 absence detection: only reply after MHI_RC_THRESHOLD consecutive unanswered 1FF7 polls.
-// -1 = not yet started, 0..MHI_RC_THRESHOLD-1 = counting, MHI_RC_THRESHOLD = absent (we reply)
-#define MHI_RC_THRESHOLD 3
-static int8_t mhiRcAbsentCnt = -1;
 // Set after publishing a 9FF7 reply; causes the next 9FF7 seen on the bus to be skipped
 // (it is our own echo) and then cleared, preventing false "RC-E5 detected" triggering.
 static bool mhiSkipNext9FF7 = false;
@@ -2772,36 +2768,13 @@ For FDYQ-like systems, try using the same commands with packet type 38 replaced 
     
 #ifdef MHI_SERIES
 
-    // MHI RC-E5 absence detection: if a 9FF7 reply is seen (even corrupted, which happens
-    // when we collide with a real RC-E5), a physical RC-E5 is present — stop emulating.
     // If mhiSkipNext9FF7 is set, the message is our own echo — skip it and clear the flag.
-    if ((nread >= 2) && (RB[0] == 0x9F) && (RB[1] == 0xF7) && (delta < MHI_RC_DELAY + 10)) {
-      if (mhiSkipNext9FF7) {
-        mhiSkipNext9FF7 = false;
-      } else {
-        if (mhiRcAbsentCnt == MHI_RC_THRESHOLD) {
-          Serial_println(F("* MHI RC-E5 detected — stopping emulation"));
-        }
-        mhiRcAbsentCnt = 0;
-      }
+    if (mhiSkipNext9FF7 && (delta < MHI_RC_DELAY + 100)) {
+      mhiSkipNext9FF7 = false;
     }
-    // MHI RC-E5 emulation: act as slave, reply to master polls addressed to 0x1FF7.
-    // Only reply after MHI_RC_THRESHOLD consecutive unanswered polls (no real RC-E5 present).
-    // State is initialised from the first 0x1FF7 frame (always an echo of actual AC state).
-    // Subsequent replies echo back the same values unless changed via the 'A' command.
-    // Checksum (byte 16) is appended by the library (cs_gen=1).
+
     if ((nread >= 15) && (RB[0] == 0x1F) && (RB[1] == 0xF7)) {
-      if (mhiRcAbsentCnt < MHI_RC_THRESHOLD) {
-        // still counting — increment and wait
-        if (mhiRcAbsentCnt < 0) mhiRcAbsentCnt = 0;
-        mhiRcAbsentCnt++;
-        if (mhiRcAbsentCnt == MHI_RC_THRESHOLD) {
-          Serial_println(F("* No RC-E5 detected — starting MHI emulation"));
-        }
-      } else if (!readError) {
-        // RC-E5 confirmed absent — build and send reply.
-        // Apply user-requested state bytes only when the 1FF7 state is unchanged since last
-        // poll (i.e. no other party on the bus changed something in between).
+      if (!readError) {
         // If the master's state changed externally, echo it this cycle and let the user
         // override take effect once the state has stabilised.
         bool stateUnchanged = (RB[2] == mhiPrevByte3) &&

--- a/examples/P1P2Monitor/mhi-xy-bus-spec.md
+++ b/examples/P1P2Monitor/mhi-xy-bus-spec.md
@@ -1,0 +1,349 @@
+# MHI X/Y Bus Protocol Specification
+
+**Source:** Reverse engineering (exablue GmbH report #2018-08-13-001 + live capture analysis)  
+**Status:** Draft — incomplete datablock (bytes 7–15) not fully decoded  
+**Tested hardware:** FDUM71VF, RC-E5, RCN-TC-24W-ER  
+
+---
+
+## 1. Physical Layer
+
+| Parameter | Value |
+|---|---|
+| Bus type | 2-wire, polarity-independent |
+| Terminals | X and Y |
+| Idle voltage | 13–18 V (measured: 16.9 V) |
+| Available current | ≥ 80 mA (parasitic power supply supported) |
+| Max bus length | 600 m |
+| Short circuit protection | Yes (triggers error code E1) |
+
+---
+
+## 2. Frame Structure
+
+Each frame is **16 bytes** (48 symbols) and takes **59.956 ms** to transmit.
+
+### Inter-frame timing
+
+| Condition | Silence duration |
+|---|---|
+| Normal operation | ~300 ms (minimum 250 ms) |
+| After command (fast propagation) | ~196–250 ms |
+| System power-up | Up to 30 seconds before first frame |
+
+### Frame layout
+
+| Byte(s) | Field | Description |
+|---|---|---|
+| 1–2 | Receiver address | 16-bit address of the target device |
+| 3 | Mode / power / swing | Operating mode, on/off state, and vane swing flag |
+| 4 | Fan speed / vane position | Fan level and fixed vane position |
+| 5 | Setpoint temperature | Target temperature |
+| 6 | Unknown temperature | Reported by AC unit; `0xFF` in RC frames |
+| 7–15 | Data block | Status/operational data (partially unknown) |
+| 16 | Checksum | `sum(byte1 .. byte15) % 255` |
+
+---
+
+## 3. Device Addresses
+
+| Address | Device | Role |
+|---|---|---|
+| `0x8001` | RCN-TC-24W-ER | Master |
+| `0x0007` | FDUM71VF indoor unit | Slave |
+| `0x1FF7` | Master poll address for RC-E5 | — |
+| `0x9FF7` | RC-E5 wired remote controller | Slave (reply address) |
+
+### Address convention
+
+The RC-E5 uses two addresses:
+- `0x1FF7` — the address the master uses to poll it
+- `0x9FF7` — the address the RC-E5 uses in its reply frames
+
+The high nibble of byte 1 flips between request and reply (`1F` → `9F`), while byte 2 (`F7`) remains identical. The checksum difference between a request and its reply is always exactly `0x80` due to this single-byte change.
+
+---
+
+## 4. Bus Session / Communication Flow
+
+### Normal cycle (no RC-E5)
+
+```
+[Master 0x8001] → 0007  poll FDUM           (gap: ~3.133 s)
+[Slave  0x0007] → 8001  FDUM reply          (gap: ~0.250 s)
+[Master 0x8001] → 0X07  scan probe          (gap: ~2.829 s)
+[Master 0x8001] → 1FF7  poll RC-E5          (gap: ~3.133 s)
+                         [silence — no RC-E5]
+```
+
+### Normal cycle (with RC-E5)
+
+```
+[Master 0x8001] → 0007  poll FDUM           (gap: ~3.133 s)
+[Slave  0x0007] → 8001  FDUM reply          (gap: ~0.250 s)
+[Master 0x8001] → 0X07  scan probe          (gap: ~2.829 s)
+[Master 0x8001] → 1FF7  poll RC-E5          (gap: ~3.133 s)
+[Slave  0x9FF7] → reply RC-E5 reply         (gap: ~0.250 s)
+```
+
+### Command cycle (RC-E5 sends a command)
+
+When RC-E5 changes state (power, temperature), the master immediately rebroadcasts to the FDUM without waiting for the normal 2.8 s cadence:
+
+```
+[Master 0x8001] → 1FF7  poll RC-E5 (with new state)
+[Slave  0x9FF7] → reply RC-E5 echoes new state    (gap: ~0.250 s)
+[Master 0x8001] → 0007  immediate FDUM update      (gap: ~0.196–0.245 s)
+[Slave  0x0007] → 8001  FDUM acknowledges          (gap: ~0.250 s)
+```
+
+### RC-E5 presence detection
+
+The `9FF7` reply frame is a reliable indicator of RC-E5 bus presence:
+- `9FF7` present → RC-E5 connected and responding
+- `9FF7` absent → RC-E5 disconnected or offline
+
+---
+
+## 5. Bus Scanning
+
+The master continuously scans for additional slave devices by probing candidate addresses. A device is discovered when it replies within ~0.250 s of being polled.
+
+### Scan pattern
+
+Starting address: `0x0107`
+
+1. Inner loop: increment by `0x1000` four times → `0x0107`, `0x1107`, `0x2107`, `0x3107`
+2. Outer loop: add `0x0100`, repeat inner loop → continues to `0x3F07`
+3. Then: `0x0017`..`0x0F17`, `0x0027`..`0x0F27`, ..., `0x0F07`..`0x0FF7`
+4. Then: `0x1FF7`, `0x2FF7`, `0x3FF7` (with different data block)
+5. Cycle repeats
+
+### Scan timing
+
+| Parameter | Value |
+|---|---|
+| Time per address probe | ~10 seconds |
+| Full cycle duration | ~29 minutes |
+| Scan rate after power loss | Faster |
+
+---
+
+## 6. Field Definitions
+
+### Byte 3 — Mode / Power / Swing
+
+| Bit | Field | Values |
+|---|---|---|
+| 1 (LSB) | On/Off | `0` = off, `1` = on |
+| 2–7 | Mode | See table below |
+| 6 | Vane swing | `0` = fixed position, `1` = swing |
+| 8 (MSB) | Unknown | `1` = default, `0` = not observed |
+
+Note: bit 6 overlaps with the mode field. Swing is only meaningful when the mode bits allow vane control.
+
+#### Mode bit patterns (bits 2–7)
+
+| Bits 2–7 | Mode |
+|---|---|
+| `010101` | Cooling only |
+| `010111` | Fan only |
+| `111001` | Heating only |
+| `010001` | Auto |
+| `010011` | Dehumidify |
+
+#### Observed byte 3 values
+
+| Value | Binary | Mode | Power | Swing |
+|---|---|---|---|---|
+| `0xAA` | `10101010` | Cooling | OFF | No |
+| `0xAB` | `10101011` | Cooling | ON | No |
+| `0xA2` | `10100010` | Auto | OFF | No |
+| `0xA3` | `10100011` | Auto | ON | No |
+| `0xAF` | `10101111` | Fan only | ON | No |
+| `0xEF` | `11101111` | Fan only | ON | Yes |
+
+### Byte 4 — Fan Speed / Vane Position
+
+Byte 4 encodes both fan speed (bits 3 and 1–0) and vane fixed position (bits 5–4). Bit 3 is always `1`.
+
+#### Bit layout
+
+| Bits | Field |
+|---|---|
+| 7–6 | Fan speed group (see below) |
+| 5–4 | Vane position (when swing = off) |
+| 3 | Always `1` |
+| 2–0 | Fan speed detail |
+
+#### Vane position (bits 5–4) — only active when byte 3 bit 6 = `0`
+
+| Bits 5–4 | Vane position | Byte 4 (fan level 1) |
+|---|---|---|
+| `00` | Top | `0x88` |
+| `01` | Mid-top | `0x98` |
+| `10` | Mid-bottom | `0xA8` |
+| `11` | Bottom | `0xB8` |
+
+Note: when swing is active (byte 3 bit 6 = `1`), byte 4 vane bits are ignored. Byte 4 = `0x98` is used as the swing default.
+
+#### Fan speed values
+
+| Value | Fan speed |
+|---|---|
+| `0x88` / `0x98` / `0xA8` / `0xB8` | Level 1 (varies by vane position) |
+| `0x99` | Level 2 |
+| `0x9A` | Level 3 |
+| `0xAA` | Off |
+
+#### Complete vane / swing mapping
+
+| Position | Byte 3 | Byte 4 | Swing active |
+|---|---|---|---|
+| Swing | `0xEF` | `0x98` | Yes |
+| Top | `0xAF` | `0x88` | No |
+| Mid-top | `0xAF` | `0x98` | No |
+| Mid-bottom | `0xAF` | `0xA8` | No |
+| Bottom | `0xAF` | `0xB8` | No |
+
+### Byte 5 — Setpoint Temperature
+
+Conversion formula: `(value - 0x80) / 2.0 = °C`
+
+| Value | Temperature |
+|---|---|
+| `0xAC` | 22.0 °C |
+| `0xAD` | 22.5 °C |
+| `0xAE` | 23.0 °C |
+
+Temperature is retained in memory after power off.
+
+### Byte 6 — Unknown Temperature
+
+Reported by the AC unit in reply frames. Set to `0xFF` in all RC/master frames.
+
+Conversion formula (same as byte 5): `(value - 0x80) / 2.0 = °C`
+
+Observed values suggest return air or coil temperature. Slowly drifts upward when unit is idle (e.g. 9.5 °C → 11.0 °C over ~5 minutes with compressor off).
+
+### Bytes 7–15 — Data Block
+
+Partially unknown. Normally `0x0000800000FFFFFFFF` in idle/off state. Transitions to live operational data when unit starts up:
+
+| State | Example value |
+|---|---|
+| Idle / off | `0000800000FFFFFFFF` |
+| Unit starting / running | `0000 0800 FF 35 10 08 01` |
+
+### Byte 16 — Checksum
+
+```
+checksum = sum(byte1 + byte2 + ... + byte15) % 255
+```
+
+Note: modulo **255** (not 256). This is not a bitwise AND with `0xFF`.
+
+#### Verified examples
+
+| Frame | Sum (decimal) | Sum % 255 | Checksum |
+|---|---|---|---|
+| `1FF7AA98ADFF0000800000FFFFFFFF` | 2176 | 128 | `0x80` ✓ |
+| `9FF7AA98ADFF0000800000FFFFFFFF` | 2304 | 0 | `0x00` ✓ |
+| `0007AA98ADFF0000800000FFFFFFFF` | 1945 | 113 | `0x71` ✓ |
+| `1FF7AB98ADFF0000800000FFFFFFFF` | 2177 | 129 | `0x81` ✓ |
+
+The checksum difference between a master poll (`1FF7`) and its RC-E5 reply (`9FF7`) is always exactly `0x80`, because only byte 1 changes (`0x1F` → `0x9F`, difference = `0x80`).
+
+---
+
+## 7. Request / Reply Mapping (RC-E5 Example)
+
+The RC-E5 is a pure echo slave — it echoes all payload bytes unchanged, only substituting its own reply address in byte 1.
+
+| Byte | Master request (`1FF7`) | RC-E5 reply (`9FF7`) | Notes |
+|---|---|---|---|
+| 1 | `1F` | `9F` | Address high byte flips |
+| 2 | `F7` | `F7` | Unchanged |
+| 3 | command | echoed | Mode/power |
+| 4 | command | echoed | Fan speed |
+| 5 | command | echoed | Setpoint |
+| 6 | `FF` | `FF` | No sensor on RC-E5 |
+| 7–15 | data block | echoed | Unchanged |
+| 16 | checksum | checksum | Recalculated (+0x80) |
+
+### Command examples
+
+**Unit off, 22.5 °C (baseline):**
+```
+Request: 1F F7 AA 98 AD FF 00 00 80 00 00 FF FF FF FF 80
+Reply:   9F F7 AA 98 AD FF 00 00 80 00 00 FF FF FF FF 00
+```
+
+**Power ON:**
+```
+Request: 1F F7 AB 98 AD FF 00 00 80 00 00 FF FF FF FF 81
+Reply:   9F F7 AB 98 AD FF 00 00 80 00 00 FF FF FF FF 01
+                ↑ AA→AB (bit 0 set)
+```
+
+**Temperature change to 23.0 °C (unit on):**
+```
+Request: 1F F7 AB 98 AE FF 00 00 80 00 00 FF FF FF FF 82
+Reply:   9F F7 AB 98 AE FF 00 00 80 00 00 FF FF FF FF 02
+                       ↑ AD→AE (+0.5 °C)
+```
+
+**Power OFF (temperature retained):**
+```
+Request: 1F F7 AA 98 AE FF 00 00 80 00 00 FF FF FF FF 81
+Reply:   9F F7 AA 98 AE FF 00 00 80 00 00 FF FF FF FF 01
+                ↑ AB→AA (bit 0 cleared)
+```
+
+**Vane swing ON (fan only mode, on):**
+```
+Request: 1F F7 EF 98 AC FF 00 00 80 00 00 FF FF FF FF C4
+Reply:   9F F7 EF 98 AC FF 00 00 80 00 00 FF FF FF FF 44
+                ↑ AF→EF (bit 6 set)
+```
+
+**Vane fixed top:**
+```
+Request: 1F F7 AF 88 AC FF 00 00 80 00 00 FF FF FF FF 74
+Reply:   9F F7 AF 88 AC FF 00 00 80 00 00 FF FF FF FF F4
+                ↑ EF→AF (bit 6 cleared)    ↑ 98→88 (bits 5–4 = 00)
+```
+
+**Vane fixed mid-top:**
+```
+Request: 1F F7 AF 98 AC FF 00 00 80 00 00 FF FF FF FF 84
+Reply:   9F F7 AF 98 AC FF 00 00 80 00 00 FF FF FF FF 04
+                            ↑ bits 5–4 = 01
+```
+
+**Vane fixed mid-bottom:**
+```
+Request: 1F F7 AF A8 AC FF 00 00 80 00 00 FF FF FF FF 94
+Reply:   9F F7 AF A8 AC FF 00 00 80 00 00 FF FF FF FF 14
+                            ↑ bits 5–4 = 10
+```
+
+**Vane fixed bottom:**
+```
+Request: 1F F7 AF B8 AC FF 00 00 80 00 00 FF FF FF FF A4
+Reply:   9F F7 AF B8 AC FF 00 00 80 00 00 FF FF FF FF 24
+                            ↑ bits 5–4 = 11
+```
+
+---
+
+## 8. Known Unknowns
+
+| Item | Status |
+|---|---|
+| Bytes 7–15 data block full decode | Not complete |
+| Byte 6 exact temperature source (coil / return air / other) | Uncertain |
+| `0x1FF7` / `0x2FF7` / `0x3FF7` different data block content | Not captured |
+| Master's own address in frame headers | Not observed transmitting as slave |
+| Multiple simultaneous slave handling | Not tested |
+| Full address space map | Scan cycle ~29 min, not fully observed |


### PR DESCRIPTION
MHI heat pump control implementation using X/Y two wire interface - P1P2 monitor mimics MHI RC-E5 wired remote control communication in slave mode (A channel). Reverse engineered communication schema is described in [mhi-xy-bus-spec.md](examples/P1P2Monitor/mhi-xy-bus-spec.md). Direct control via MH command added for testing purposes (e.g. `MH AB 98 AC
` power on 22C cooling).